### PR TITLE
build with Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = builtins.fetchGit ./.;
+}).defaultNix

--- a/eclair-lang.cabal
+++ b/eclair-lang.cabal
@@ -1,10 +1,10 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d1ee9dddd03131277d842aea3755eb9f758ba3c896a0d50c9ef0766f04007f79
+-- hash: 4592e28a788e200b43e756522bed75e3649c08b124bf08ef35afd858d9ad5236
 
 name:           eclair-lang
 version:        0.1.0.0
@@ -43,9 +43,30 @@ library
       Eclair.TypeSystem
   other-modules:
       Paths_eclair_lang
+  autogen-modules:
+      Paths_eclair_lang
   hs-source-dirs:
       lib
-  default-extensions: NoImplicitPrelude OverloadedStrings LambdaCase ViewPatterns RankNTypes TypeFamilies DataKinds KindSignatures TupleSections DeriveFunctor DeriveFoldable DeriveTraversable DeriveGeneric DeriveAnyClass DerivingStrategies DerivingVia FlexibleContexts FlexibleInstances ScopedTypeVariables
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+      LambdaCase
+      ViewPatterns
+      RankNTypes
+      TypeFamilies
+      DataKinds
+      KindSignatures
+      TupleSections
+      DeriveFunctor
+      DeriveFoldable
+      DeriveTraversable
+      DeriveGeneric
+      DeriveAnyClass
+      DerivingStrategies
+      DerivingVia
+      FlexibleContexts
+      FlexibleInstances
+      ScopedTypeVariables
   ghc-options: -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits
   cxx-options: -std=c++20 -D__EMBEDDED_SOUFFLE__ -Wall
   build-depends:
@@ -65,7 +86,7 @@ library
     , prettyprinter ==1.*
     , protolude ==0.3.0
     , recursion-schemes ==5.*
-    , souffle-haskell ==3.0.0
+    , souffle-haskell ==3.1.0
     , text ==1.*
     , transformers ==0.*
     , vector ==0.12.*
@@ -85,9 +106,30 @@ executable eclairc
   main-is: Main.hs
   other-modules:
       Paths_eclair_lang
+  autogen-modules:
+      Paths_eclair_lang
   hs-source-dirs:
       src
-  default-extensions: NoImplicitPrelude OverloadedStrings LambdaCase ViewPatterns RankNTypes TypeFamilies DataKinds KindSignatures TupleSections DeriveFunctor DeriveFoldable DeriveTraversable DeriveGeneric DeriveAnyClass DerivingStrategies DerivingVia FlexibleContexts FlexibleInstances ScopedTypeVariables
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+      LambdaCase
+      ViewPatterns
+      RankNTypes
+      TypeFamilies
+      DataKinds
+      KindSignatures
+      TupleSections
+      DeriveFunctor
+      DeriveFoldable
+      DeriveTraversable
+      DeriveGeneric
+      DeriveAnyClass
+      DerivingStrategies
+      DerivingVia
+      FlexibleContexts
+      FlexibleInstances
+      ScopedTypeVariables
   ghc-options: -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits -threaded -rtsopts -with-rtsopts=-N
   cxx-options: -std=c++20 -D__EMBEDDED_SOUFFLE__
   build-depends:
@@ -109,7 +151,7 @@ executable eclairc
     , prettyprinter ==1.*
     , protolude ==0.3.0
     , recursion-schemes ==5.*
-    , souffle-haskell ==3.0.0
+    , souffle-haskell ==3.1.0
     , text ==1.*
     , transformers ==0.*
     , vector ==0.12.*
@@ -131,9 +173,30 @@ test-suite eclair-test
       Test.Eclair.RA.InterpreterSpec
       Test.Eclair.Runtime.HashSpec
       Paths_eclair_lang
+  autogen-modules:
+      Paths_eclair_lang
   hs-source-dirs:
       tests
-  default-extensions: NoImplicitPrelude OverloadedStrings LambdaCase ViewPatterns RankNTypes TypeFamilies DataKinds KindSignatures TupleSections DeriveFunctor DeriveFoldable DeriveTraversable DeriveGeneric DeriveAnyClass DerivingStrategies DerivingVia FlexibleContexts FlexibleInstances ScopedTypeVariables
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+      LambdaCase
+      ViewPatterns
+      RankNTypes
+      TypeFamilies
+      DataKinds
+      KindSignatures
+      TupleSections
+      DeriveFunctor
+      DeriveFoldable
+      DeriveTraversable
+      DeriveGeneric
+      DeriveAnyClass
+      DerivingStrategies
+      DerivingVia
+      FlexibleContexts
+      FlexibleInstances
+      ScopedTypeVariables
   ghc-options: -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits
   cxx-options: -std=c++20 -D__EMBEDDED_SOUFFLE__
   build-depends:
@@ -159,7 +222,7 @@ test-suite eclair-test
     , prettyprinter ==1.*
     , protolude ==0.3.0
     , recursion-schemes ==5.*
-    , souffle-haskell ==3.0.0
+    , souffle-haskell ==3.1.0
     , text ==1.*
     , transformers ==0.*
     , vector ==0.12.*

--- a/eclair-lang.cabal
+++ b/eclair-lang.cabal
@@ -1,10 +1,10 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.34.6.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4592e28a788e200b43e756522bed75e3649c08b124bf08ef35afd858d9ad5236
+-- hash: d1ee9dddd03131277d842aea3755eb9f758ba3c896a0d50c9ef0766f04007f79
 
 name:           eclair-lang
 version:        0.1.0.0
@@ -43,30 +43,9 @@ library
       Eclair.TypeSystem
   other-modules:
       Paths_eclair_lang
-  autogen-modules:
-      Paths_eclair_lang
   hs-source-dirs:
       lib
-  default-extensions:
-      NoImplicitPrelude
-      OverloadedStrings
-      LambdaCase
-      ViewPatterns
-      RankNTypes
-      TypeFamilies
-      DataKinds
-      KindSignatures
-      TupleSections
-      DeriveFunctor
-      DeriveFoldable
-      DeriveTraversable
-      DeriveGeneric
-      DeriveAnyClass
-      DerivingStrategies
-      DerivingVia
-      FlexibleContexts
-      FlexibleInstances
-      ScopedTypeVariables
+  default-extensions: NoImplicitPrelude OverloadedStrings LambdaCase ViewPatterns RankNTypes TypeFamilies DataKinds KindSignatures TupleSections DeriveFunctor DeriveFoldable DeriveTraversable DeriveGeneric DeriveAnyClass DerivingStrategies DerivingVia FlexibleContexts FlexibleInstances ScopedTypeVariables
   ghc-options: -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits
   cxx-options: -std=c++20 -D__EMBEDDED_SOUFFLE__ -Wall
   build-depends:
@@ -86,7 +65,7 @@ library
     , prettyprinter ==1.*
     , protolude ==0.3.0
     , recursion-schemes ==5.*
-    , souffle-haskell ==3.1.0
+    , souffle-haskell ==3.0.0
     , text ==1.*
     , transformers ==0.*
     , vector ==0.12.*
@@ -106,30 +85,9 @@ executable eclairc
   main-is: Main.hs
   other-modules:
       Paths_eclair_lang
-  autogen-modules:
-      Paths_eclair_lang
   hs-source-dirs:
       src
-  default-extensions:
-      NoImplicitPrelude
-      OverloadedStrings
-      LambdaCase
-      ViewPatterns
-      RankNTypes
-      TypeFamilies
-      DataKinds
-      KindSignatures
-      TupleSections
-      DeriveFunctor
-      DeriveFoldable
-      DeriveTraversable
-      DeriveGeneric
-      DeriveAnyClass
-      DerivingStrategies
-      DerivingVia
-      FlexibleContexts
-      FlexibleInstances
-      ScopedTypeVariables
+  default-extensions: NoImplicitPrelude OverloadedStrings LambdaCase ViewPatterns RankNTypes TypeFamilies DataKinds KindSignatures TupleSections DeriveFunctor DeriveFoldable DeriveTraversable DeriveGeneric DeriveAnyClass DerivingStrategies DerivingVia FlexibleContexts FlexibleInstances ScopedTypeVariables
   ghc-options: -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits -threaded -rtsopts -with-rtsopts=-N
   cxx-options: -std=c++20 -D__EMBEDDED_SOUFFLE__
   build-depends:
@@ -151,7 +109,7 @@ executable eclairc
     , prettyprinter ==1.*
     , protolude ==0.3.0
     , recursion-schemes ==5.*
-    , souffle-haskell ==3.1.0
+    , souffle-haskell ==3.0.0
     , text ==1.*
     , transformers ==0.*
     , vector ==0.12.*
@@ -173,30 +131,9 @@ test-suite eclair-test
       Test.Eclair.RA.InterpreterSpec
       Test.Eclair.Runtime.HashSpec
       Paths_eclair_lang
-  autogen-modules:
-      Paths_eclair_lang
   hs-source-dirs:
       tests
-  default-extensions:
-      NoImplicitPrelude
-      OverloadedStrings
-      LambdaCase
-      ViewPatterns
-      RankNTypes
-      TypeFamilies
-      DataKinds
-      KindSignatures
-      TupleSections
-      DeriveFunctor
-      DeriveFoldable
-      DeriveTraversable
-      DeriveGeneric
-      DeriveAnyClass
-      DerivingStrategies
-      DerivingVia
-      FlexibleContexts
-      FlexibleInstances
-      ScopedTypeVariables
+  default-extensions: NoImplicitPrelude OverloadedStrings LambdaCase ViewPatterns RankNTypes TypeFamilies DataKinds KindSignatures TupleSections DeriveFunctor DeriveFoldable DeriveTraversable DeriveGeneric DeriveAnyClass DerivingStrategies DerivingVia FlexibleContexts FlexibleInstances ScopedTypeVariables
   ghc-options: -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits
   cxx-options: -std=c++20 -D__EMBEDDED_SOUFFLE__
   build-depends:
@@ -222,7 +159,7 @@ test-suite eclair-test
     , prettyprinter ==1.*
     , protolude ==0.3.0
     , recursion-schemes ==5.*
-    , souffle-haskell ==3.1.0
+    , souffle-haskell ==3.0.0
     , text ==1.*
     , transformers ==0.*
     , vector ==0.12.*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,179 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "fu": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "master",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1611672876,
+        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1639977137,
+        "narHash": "sha256-r3f3DRZy1SVCqrjlzv3SzSZKzeeHK8a124Dd8ZoKO3E=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "e1949dd5e37db2b0a3b5490bc52976fd154d794d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "master",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1639357775,
+        "narHash": "sha256-mJJFCPqZi1ZO3CvgEfN2nFAYv4uAJSRnTKzLFi61+WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c473cc8714710179df205b153f4e9fa007107ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1639955162,
+        "narHash": "sha256-bRhzK0h4n1YirCsJz7pkpXXy2+ruth/bUh7PwRrRnW4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2beba9a23a8381eb95187f46b10c3677d8f63ca1",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "np": {
+      "locked": {
+        "lastModified": 1639975477,
+        "narHash": "sha256-QRORrBxM0p83NFTN+4eL7ragCRLxVHb9JMwBL6faQ3M=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e7eb62576c8d3bba35136fdafb80ae1aa8e92a05",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1624971177,
+        "narHash": "sha256-Amf/nBj1E77RmbSSmV+hg6YOpR+rddCbbVgo5C7BS0I=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "397f0713d007250a2c7a745e555fa16c5dc8cadb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fu": "fu",
+        "hls": "hls",
+        "np": "np"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -133,16 +133,16 @@
     },
     "np": {
       "locked": {
-        "lastModified": 1640269308,
-        "narHash": "sha256-vBVwv3+kPrxbNyfo48cB5cc5/4tq5zlJGas/qw8XNBE=",
+        "lastModified": 1640243785,
+        "narHash": "sha256-i4y7wKsfxcWeqRL07X9QSOIXnis/ECrGwc45leSrrPI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c408a087b4751c887e463e3848512c12017be25",
+        "rev": "92161fcfda8cf4b447a05f527e3a03f43402bf87",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "master",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1639977137,
-        "narHash": "sha256-r3f3DRZy1SVCqrjlzv3SzSZKzeeHK8a124Dd8ZoKO3E=",
+        "lastModified": 1640266305,
+        "narHash": "sha256-n0G5pBPMAfn1Vwc62HFcDuQmx+OKJd6b4AtkDluqkWU=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "e1949dd5e37db2b0a3b5490bc52976fd154d794d",
+        "rev": "9797e1be9d164b19de721cd143f696d2245e49a8",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1639955162,
-        "narHash": "sha256-bRhzK0h4n1YirCsJz7pkpXXy2+ruth/bUh7PwRrRnW4=",
+        "lastModified": 1640234302,
+        "narHash": "sha256-dALA+cOam5jQ2KOYdWiv6H6Y2stcYG6eclWQQVGx/FI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2beba9a23a8381eb95187f46b10c3677d8f63ca1",
+        "rev": "81cbfc8f2a1e218249b7bff74013b63150171496",
         "type": "github"
       },
       "original": {
@@ -133,11 +133,11 @@
     },
     "np": {
       "locked": {
-        "lastModified": 1639975477,
-        "narHash": "sha256-QRORrBxM0p83NFTN+4eL7ragCRLxVHb9JMwBL6faQ3M=",
+        "lastModified": 1640269308,
+        "narHash": "sha256-vBVwv3+kPrxbNyfo48cB5cc5/4tq5zlJGas/qw8XNBE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7eb62576c8d3bba35136fdafb80ae1aa8e92a05",
+        "rev": "0c408a087b4751c887e463e3848512c12017be25",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -347,11 +347,11 @@
         "np": "np_2"
       },
       "locked": {
-        "lastModified": 1640536645,
-        "narHash": "sha256-53Hh4Fk1r3ByOSmTIbZL0802tKlRLhirkIfJSMChcpI=",
+        "lastModified": 1640606965,
+        "narHash": "sha256-Jr6izvIsBEPZiMWz4rjmRD2QHJdNUAPa+ryYZY1hkMo=",
         "owner": "luc-tielen",
         "repo": "souffle-haskell",
-        "rev": "a0f8f993e3cbc7e2f0aa7548018892bf8bb2cb38",
+        "rev": "7bfa29f52f2056459d160e795d2e7b8f36af801a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1629481132,
@@ -46,7 +62,53 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "fu": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "master",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "fu_2": {
       "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
@@ -78,6 +140,22 @@
         "type": "github"
       }
     },
+    "gitignore_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1611672876,
+        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "hls": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -87,11 +165,34 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1640266305,
-        "narHash": "sha256-n0G5pBPMAfn1Vwc62HFcDuQmx+OKJd6b4AtkDluqkWU=",
+        "lastModified": 1640517779,
+        "narHash": "sha256-NvoorcPbmgBcKURN5eVUKlAE6PWcwggzMgXRFrDKKGs=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "9797e1be9d164b19de721cd143f696d2245e49a8",
+        "rev": "b35420203b5627585afbd27aac5b3cdb4c9d0b84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "master",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_3",
+        "gitignore": "gitignore_2",
+        "nixpkgs": "nixpkgs_3",
+        "pre-commit-hooks": "pre-commit-hooks_2"
+      },
+      "locked": {
+        "lastModified": 1640382017,
+        "narHash": "sha256-o/3unZLhE/KPoXgdsJYBPJWAeMNiVyzWwPUR+YBTOUg=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7c9b9327d83261a6d40e54a4a2078667f0ddc7bd",
         "type": "github"
       },
       "original": {
@@ -119,11 +220,41 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1640234302,
-        "narHash": "sha256-dALA+cOam5jQ2KOYdWiv6H6Y2stcYG6eclWQQVGx/FI=",
+        "lastModified": 1640418986,
+        "narHash": "sha256-a8GGtxn2iL3WAkY5H+4E0s3Q7XJt6bTOvos9qqxT5OQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "81cbfc8f2a1e218249b7bff74013b63150171496",
+        "rev": "5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1639357775,
+        "narHash": "sha256-mJJFCPqZi1ZO3CvgEfN2nFAYv4uAJSRnTKzLFi61+WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c473cc8714710179df205b153f4e9fa007107ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1640328990,
+        "narHash": "sha256-KQbvJx4qO9bo04tfTZuISyY4vRC5k3ZB3lyLS21XWIw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ab93217a2b74a1c36bc892c14f44ee5959c33f12",
         "type": "github"
       },
       "original": {
@@ -133,11 +264,27 @@
     },
     "np": {
       "locked": {
-        "lastModified": 1640243785,
-        "narHash": "sha256-i4y7wKsfxcWeqRL07X9QSOIXnis/ECrGwc45leSrrPI=",
+        "lastModified": 1640563707,
+        "narHash": "sha256-3xpdcVvFH8b7O9H/0bB/461T/JH5VKDXrza2l7ob7pk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "92161fcfda8cf4b447a05f527e3a03f43402bf87",
+        "rev": "c52815aa6da29983e341659c4662941a2f7797ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "haskell-updates",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "np_2": {
+      "locked": {
+        "lastModified": 1640390856,
+        "narHash": "sha256-bBLSbuAp+f1/C0SSwvi7Gb5hAotGt/Lr4e233zb8DmU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0587013dd2719891573732e5c0fd718e92b25501",
         "type": "github"
       },
       "original": {
@@ -166,11 +313,52 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1624971177,
+        "narHash": "sha256-Amf/nBj1E77RmbSSmV+hg6YOpR+rddCbbVgo5C7BS0I=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "397f0713d007250a2c7a745e555fa16c5dc8cadb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "fu": "fu",
         "hls": "hls",
-        "np": "np"
+        "np": "np",
+        "shs": "shs"
+      }
+    },
+    "shs": {
+      "inputs": {
+        "fu": "fu_2",
+        "hls": "hls_2",
+        "np": "np_2"
+      },
+      "locked": {
+        "lastModified": 1640536645,
+        "narHash": "sha256-53Hh4Fk1r3ByOSmTIbZL0802tKlRLhirkIfJSMChcpI=",
+        "owner": "luc-tielen",
+        "repo": "souffle-haskell",
+        "rev": "a0f8f993e3cbc7e2f0aa7548018892bf8bb2cb38",
+        "type": "github"
+      },
+      "original": {
+        "owner": "luc-tielen",
+        "ref": "master",
+        "repo": "souffle-haskell",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           with final.haskell.lib;
           with final.haskellPackages.extend (final: super:
             let
-              lhsGit = fetchFromGitHub {
+              llvmHsGit = fetchFromGitHub {
                 owner = "luc-tielen";
                 repo = "llvm-hs";
                 rev = "69ae96c9eea8531c750c9d81f9813286ef5ced81";
@@ -30,11 +30,11 @@
 
               llvm-hs-pure = with final;
                 addBuildTools (callCabal2nixWithOptions "llvm-hs-pure"
-                  "${lhsGit}/llvm-hs-pure" "" { }) [ ];
+                  "${llvmHsGit}/llvm-hs-pure" "" { }) [ ];
 
               llvm-hs = with final;
                 dontHaddock
-                (callCabal2nixWithOptions "llvm-hs" "${lhsGit}/llvm-hs" "" {
+                (callCabal2nixWithOptions "llvm-hs" "${llvmHsGit}/llvm-hs" "" {
                   inherit llvm-hs-pure;
                   llvm-config = llvmPackages_9.llvm;
                 });
@@ -77,8 +77,7 @@
                   };
                 });
             }); {
-              eclair-lang =
-                callCabal2nixWithOptions "eclair-lang" ./. "-fdebug" { };
+              eclair-lang = callCabal2nix "eclair-lang" ./. { };
             };
         overlays = [ overlay hls.overlay ] ++ shs.overlays."${system}";
       in with (import np { inherit system config overlays; });

--- a/flake.nix
+++ b/flake.nix
@@ -78,10 +78,7 @@
                 });
             }); {
               eclair-lang =
-                callCabal2nixWithOptions "eclair-lang" ./. "-fdebug" {
-                  inherit algebraic-graphs llvm-hs-pure llvm-hs
-                    haskell-stack-trace-plugin;
-                };
+                callCabal2nixWithOptions "eclair-lang" ./. "-fdebug" { };
             };
         overlays = [ overlay hls.overlay ] ++ shs.overlays."${system}";
       in with (import np { inherit system config overlays; });

--- a/flake.nix
+++ b/flake.nix
@@ -23,18 +23,6 @@
                 rev = "69ae96c9eea8531c750c9d81f9813286ef5ced81";
                 sha256 = "180ssgmi8f7j0wcbwj82rhn1375mgq9q8cirkrfw4yld1wz9wfpx";
               };
-              ppGit = fetchFromGitHub {
-                owner = "quchen";
-                repo = "prettyprinter";
-                rev = "v1.6.2";
-                sha256 = "0f88y96f74a020iwzfs5c414nlh2kdpsl35v8sg42jjvlnyrqcl1";
-              };
-              ppGit' = fetchFromGitHub {
-                owner = "quchen";
-                repo = "prettyprinter";
-                rev = "v1.7.0";
-                sha256 = "00p30lpm0fijr6caal765jnjls6xjp58qd8bjx0b1dvylwm4avkw";
-              };
             in rec {
               inherit (shs.packages."${system}") souffle-haskell;
 
@@ -81,10 +69,19 @@
                     sha256 =
                       "10jdy8hvjadnrrq2ch2sxcv9mk7l1q7p12w9d3bwhrgzfm3hb9sx";
                   }) "" { });
+              haskell-stack-trace-plugin = with final;
+                dontCheck (callHackage "haskell-stack-trace-plugin" "0.1.3.0" {
+                  hspec = callHackage "hspec" "2.8.5" {
+                    hspec-core = callHackage "hspec-core" "2.8.5" { };
+                    hspec-discover = callHackage "hspec-discover" "2.8.5" { };
+                  };
+                });
             }); {
-              eclair-lang = dontCheck (callCabal2nix "eclair-lang" ./. {
-                inherit algebraic-graphs llvm-hs-pure llvm-hs;
-              });
+              eclair-lang =
+                callCabal2nixWithOptions "eclair-lang" ./. "-fdebug" {
+                  inherit algebraic-graphs llvm-hs-pure llvm-hs
+                    haskell-stack-trace-plugin;
+                };
             };
         overlays = [ overlay hls.overlay ] ++ shs.overlays."${system}";
       in with (import np { inherit system config overlays; });

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
-  description = "eclair-lang: souffle on LLVM";
+  description =
+    "eclair-lang: An experimental and minimal Datalog that compiles to LLVM";
   inputs = {
     np.url = "github:nixos/nixpkgs?ref=haskell-updates";
     fu.url = "github:numtide/flake-utils?ref=master";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "eclair-lang: souffle on LLVM";
+  inputs = {
+    np.url = "github:nixos/nixpkgs?ref=master";
+    fu.url = "github:numtide/flake-utils?ref=master";
+    hls.url = "github:haskell/haskell-language-server?ref=master";
+  };
+  outputs = { self, np, fu, hls }:
+    with fu.lib;
+    eachSystem [ "x86_64-linux" ] (system:
+      let
+        config = { allowBroken = true; };
+        overlay = final: _:
+          with final;
+          with final.haskell.lib;
+          with final.haskellPackages.extend (final: super: {
+            souffle-haskell = with super; dontCheck souffle-haskell;
+            algebraic-graphs = with final;
+              dontCheck (callCabal2nixWithOptions "algebraic-graphs"
+                (fetchFromGitHub {
+                  owner = "snowleopard";
+                  repo = "alga";
+                  rev = "75de41a4323ab9e58ca49dbd78b77f307b189795";
+                  sha256 =
+                    "10jdy8hvjadnrrq2ch2sxcv9mk7l1q7p12w9d3bwhrgzfm3hb9sx";
+                }) "" { });
+          }); {
+            eclair-lang = dontCheck (callCabal2nix "eclair-lang" ./. { });
+          };
+        overlays = [ overlay hls.overlay ];
+      in with (import np { inherit system config overlays; });
+      with np.lib; rec {
+        inherit overlays;
+        packages = flattenTree (recurseIntoAttrs { inherit eclair-lang; });
+        defaultPackage = packages.eclair-lang;
+        devShell = mkShell {
+          packages = [ haskellPackages.llvm-hs eclair-lang ];
+          buildInputs = [
+            haskellPackages.hsc2hs
+            haskellPackages.llvm-hs
+            haskell-language-server
+            ghc
+            cabal-install
+            llvmPackages_9.llvm
+          ];
+        };
+      });
+}

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,13 @@
+cradle:
+  cabal:
+    - path: "lib"
+      component: "lib:eclair-lang"
+
+    - path: "src/Main.hs"
+      component: "eclair-lang:exe:eclairc"
+
+    - path: "src/Paths_eclair_lang.hs"
+      component: "eclair-lang:exe:eclairc"
+
+    - path: "tests"
+      component: "eclair-lang:test:eclair-test"

--- a/package.yaml
+++ b/package.yaml
@@ -28,10 +28,10 @@ dependencies:
   - mtl == 2.*
   - mmorph == 1.*
   - exceptions == 0.10.*
-  - lens == 4.*  # TODO: use microlens?
+  - lens == 4.* # TODO: use microlens?
   - prettyprinter == 1.*
   - megaparsec == 9.*
-  - souffle-haskell == 3.0.0
+  - souffle-haskell == 3.1.0
   - recursion-schemes == 5.*
   - algebraic-graphs == 0.*
   - llvm-hs == 9.*

--- a/patches/1-llvm-hs-pretty.patch
+++ b/patches/1-llvm-hs-pretty.patch
@@ -1,0 +1,13 @@
+diff --git a/llvm-hs-pretty.cabal b/llvm-hs-pretty.cabal
+index 72589ae..c982478 100644
+--- a/llvm-hs-pretty.cabal
++++ b/llvm-hs-pretty.cabal
+@@ -30,7 +30,7 @@ library
+     bytestring           >= 0.1   && < 0.11,
+     llvm-hs-pure         >= 9.0   && < 10.0,
+     text                 >= 1.2   && < 2.0,
+-    prettyprinter        >= 1.2   && < 1.6
++    prettyprinter        >= 1.2   
+ 
+ Test-suite test
+   type:                exitcode-stdio-1.0

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = builtins.fetchGit ./.;
+}).shellNix


### PR DESCRIPTION
Hopefully this will make builds reproducible enough for other nix'ers. I had issues building `eclair-lang` on nixos, mainly because souffle-haskell and algebraic-graphs don't currently build on NixOs. So I've disabled the tests and I'm pulling the sources right from GitHub (instead of Hackage).