### PR TITLE
Cleanup main compiler pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ cabal.project.local*
 *.bc
 *.o
 *.s
+
+result

--- a/eclair-lang.cabal
+++ b/eclair-lang.cabal
@@ -75,6 +75,7 @@ library
     , bytestring ==0.10.*
     , comonad ==5.*
     , containers ==0.*
+    , dependent-sum-template ==0.1.*
     , exceptions ==0.10.*
     , extra ==1.*
     , lens ==4.*
@@ -88,6 +89,8 @@ library
     , prettyprinter ==1.7.*
     , recursion-schemes ==5.*
     , relude ==1.0.*
+    , rock ==0.3.*
+    , some ==1.*
     , souffle-haskell ==3.3.0
     , text ==1.*
     , transformers ==0.*
@@ -141,6 +144,7 @@ executable eclairc
     , bytestring ==0.10.*
     , comonad ==5.*
     , containers ==0.*
+    , dependent-sum-template ==0.1.*
     , directory ==1.*
     , eclair-lang
     , exceptions ==0.10.*
@@ -156,6 +160,8 @@ executable eclairc
     , prettyprinter ==1.7.*
     , recursion-schemes ==5.*
     , relude ==1.0.*
+    , rock ==0.3.*
+    , some ==1.*
     , souffle-haskell ==3.3.0
     , text ==1.*
     , transformers ==0.*
@@ -215,6 +221,7 @@ test-suite eclair-test
     , bytestring ==0.10.*
     , comonad ==5.*
     , containers ==0.*
+    , dependent-sum-template ==0.1.*
     , eclair-lang
     , exceptions ==0.10.*
     , extra ==1.*
@@ -234,6 +241,8 @@ test-suite eclair-test
     , prettyprinter ==1.7.*
     , recursion-schemes ==5.*
     , relude ==1.0.*
+    , rock ==0.3.*
+    , some ==1.*
     , souffle-haskell ==3.3.0
     , text ==1.*
     , transformers ==0.*

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
         version = "${ghcVersion}.${substring 0 8 self.lastModifiedDate}.${
             self.shortRev or "dirty"
           }";
-        config = { };
+        config = {};
         overlay = final: _:
           let
             haskellPackages =
@@ -63,6 +63,9 @@
                     algebraic-graphs = with hf;
                       dontCheck
                       (callCabal2nix "algebraic-graphs" (inputs.alga) { });
+
+                    dependent-hashmap = with hf;
+                      unmarkBroken (dontCheck hp.dependent-hashmap);
 
                     relude = hf.relude_1_0_0_1;
 

--- a/lib/Eclair.hs
+++ b/lib/Eclair.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs, QuasiQuotes, TemplateHaskell #-}
+
 module Eclair
   ( parse
   , compileRA
@@ -6,6 +8,7 @@ module Eclair
   , compile
   , run
   , EclairError(..)
+  , handleErrors
   ) where
 
 import qualified Data.Map as M
@@ -22,6 +25,10 @@ import qualified Eclair.TypeSystem as TS
 import LLVM.AST (Module)
 import Control.Exception
 import LLVM.Pretty
+import qualified Rock
+import Data.GADT.Compare.TH (deriveGEq)
+import Data.Some
+import Data.Maybe
 
 
 type Relation = RA.Relation
@@ -33,43 +40,80 @@ data EclairError
   | TypeErr [TS.TypeError]
   deriving (Show, Exception)
 
--- TODO: refactor all these helper functions to be more composable
+
+data Query a where
+  Parse :: FilePath -> Query (IO AST)
+  Typecheck :: FilePath -> Query (IO TS.TypeInfo)
+  CompileRA :: FilePath -> Query (IO RA)
+  CompileEIR :: FilePath -> Query (IO EIR)
+  CompileLLVM :: FilePath -> Query (IO Module)
+
+deriveGEq ''Query
+
+instance Hashable (Query a) where
+  hashWithSalt salt = \case
+    Parse path ->
+      hashWithSalt salt (path, 0 :: Int)
+    Typecheck path ->
+      hashWithSalt salt (path, 1 :: Int)
+    CompileRA path ->
+      hashWithSalt salt (path, 2 :: Int)
+    CompileEIR path ->
+      hashWithSalt salt (path, 3 :: Int)
+    CompileLLVM path ->
+      hashWithSalt salt (path, 4 :: Int)
+
+instance Hashable (Some Query) where
+  hashWithSalt salt (Some query) =
+    hashWithSalt salt query
+
+rules :: Rock.Rules Query
+rules = \case
+  Parse path ->
+    pure $ either (throwIO . ParseErr) pure =<< parseFile path
+  Typecheck path -> do
+    ast <- Rock.fetch (Parse path)
+    pure $ either (throwIO . TypeErr) pure . TS.typeCheck =<< ast
+  CompileRA path -> do
+    ast <- Rock.fetch (Parse path)
+    pure $ compileToRA <$> ast
+  CompileEIR path -> do
+    ra <- Rock.fetch (CompileRA path)
+    typeInfo <- Rock.fetch (Typecheck path)
+    pure $ compileToEIR <$> typeInfo <*> ra
+  CompileLLVM path -> do
+    eir <- Rock.fetch (CompileEIR path)
+    pure $ compileToLLVM =<< eir
+
+runQuery :: Query a -> IO a
+runQuery query = do
+  memoVar <- newIORef mempty
+  let task = Rock.fetch query
+  Rock.runTask (Rock.memoise memoVar rules) task
 
 parse :: FilePath -> IO AST
-parse path =
-  parseFile path >>= either (throwIO . ParseErr) pure
-
-typeCheck :: FilePath -> IO TS.TypeInfo
-typeCheck path = do
-  ast <- parse path
-  either (throwIO . TypeErr) pure $ TS.typeCheck ast
+parse = join . runQuery . Parse
 
 compileRA :: FilePath -> IO RA
-compileRA path = do
-  ast <- parse path
-  typeInfo <- typeCheck path  -- TODO don't re-parse
-  pure $ compileToRA ast
+compileRA =
+  join . runQuery . CompileRA
 
 compileEIR :: FilePath -> IO EIR
-compileEIR path = do
-  ra <- compileRA path
-  typeInfo <- typeCheck path  -- TODO don't re-parse
-  pure $ compileToEIR typeInfo ra
+compileEIR =
+  join . runQuery . CompileEIR
 
 compileLLVM :: FilePath -> IO Module
-compileLLVM path =
-  compileToLLVM =<< compileEIR path
+compileLLVM =
+  join . runQuery . CompileLLVM
 
-compile :: FilePath -> IO ()
-compile path = handle handleErrors $ do
-  llvmModule <- compileLLVM path
-  putLTextLn $ ppllvm llvmModule
+compile :: FilePath -> IO Module
+compile = compileLLVM
 
 run :: FilePath -> IO (M.Map Relation [[Number]])
-run path = do
-  ra <- compileRA path
-  interpretRA ra
+run =
+  interpretRA <=< join . runQuery . CompileRA
 
+-- TODO: improve error handling...
 handleErrors :: EclairError -> IO ()
 handleErrors = \case
   ParseErr err -> do
@@ -78,3 +122,4 @@ handleErrors = \case
   TypeErr errs -> do
     print errs
     panic "Failed to type-check file."
+

--- a/lib/Eclair.hs
+++ b/lib/Eclair.hs
@@ -120,6 +120,6 @@ handleErrors = \case
     printParseError err
     panic "Failed to parse file."
   TypeErr errs -> do
-    print errs
+    traverse_ print errs
     panic "Failed to type-check file."
 

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,9 @@ dependencies:
   - llvm-hs-pure == 9.*
   - llvm-hs-pretty == 0.9.0.0
   - llvm-hs-combinators == 0.1.*
+  - rock == 0.3.*
+  - dependent-sum-template == 0.1.*
+  - some == 1.*
 
 default-extensions:
   - OverloadedStrings

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import qualified Data.Text.Lazy.IO as T
+import Control.Exception
 import LLVM.Pretty
 import Eclair
 
@@ -12,7 +13,6 @@ main = do
     Nothing -> panic "Expected usage: 'eclairc FILE'"
     Just args -> do
       let filePath = head args
-      compile filePath >>= \case
-        Left _ -> panic "Failed to compile the Datalog code!"
-        Right llvmModule -> do
-          putLTextLn $ ppllvm llvmModule
+      handle handleErrors $ do
+        llvmModule <- compile filePath
+        putLTextLn $ ppllvm llvmModule

--- a/tests/Test/Eclair/AST/LowerSpec.hs
+++ b/tests/Test/Eclair/AST/LowerSpec.hs
@@ -19,11 +19,8 @@ import Eclair.AST.Lower
 cg :: FilePath -> IO T.Text
 cg path = do
   let file = "tests/fixtures" </> path <.> "dl"
-  result <- compileRA file
-  case result of
-    Left (ParseErr _) -> panic $ "Failed to parse " <> toText file <> "!"
-    Left (TypeErr _) -> panic $ "Failed to typecheck " <> toText file <> "!"
-    Right ra -> pure $ printDoc ra
+  ra <- compileRA file
+  pure $ printDoc ra
 
 resultsIn :: IO T.Text -> T.Text -> IO ()
 resultsIn action output = do

--- a/tests/Test/Eclair/EIR/LowerSpec.hs
+++ b/tests/Test/Eclair/EIR/LowerSpec.hs
@@ -21,10 +21,8 @@ import LLVM.Pretty
 cg :: FilePath -> IO T.Text
 cg path = do
   let file = "tests/fixtures" </> path <.> "dl"
-  result <- compileLLVM file
-  case result of
-    Left err -> panic $ "Failed to parse " <> toText file <> "!"
-    Right llvm -> pure $ toStrict $ ppllvm llvm
+  llvm <- compileLLVM file
+  pure $ toStrict $ ppllvm llvm
 
 extractDeclTypeSnippet :: Text -> Text
 extractDeclTypeSnippet result =

--- a/tests/Test/Eclair/RA/IndexSelectionSpec.hs
+++ b/tests/Test/Eclair/RA/IndexSelectionSpec.hs
@@ -6,7 +6,6 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Test.Hspec
 import System.FilePath
-import Eclair
 import Eclair.Id
 import Eclair.Parser
 import Eclair.AST.Lower
@@ -18,7 +17,7 @@ import qualified Data.Text as T
 idxSel :: FilePath -> IO IndexMap
 idxSel path = do
   let file = "tests/fixtures" </> path <.> "dl"
-  parseResult <- parse file
+  parseResult <- parseFile file
   case parseResult of
     Left err -> panic $ "Failed to parse " <> toText file <> "!"
     Right ast -> do

--- a/tests/Test/Eclair/RA/LowerSpec.hs
+++ b/tests/Test/Eclair/RA/LowerSpec.hs
@@ -16,10 +16,8 @@ import NeatInterpolation
 cg :: FilePath -> IO T.Text
 cg path = do
   let file = "tests/fixtures" </> path <.> "dl"
-  result <- compileEIR file
-  case result of
-    Left err -> panic $ "Failed to parse " <> toText file <> "!"
-    Right eir -> pure $ printDoc eir
+  eir <- compileEIR file
+  pure $ printDoc eir
 
 extractDeclTypeSnippet :: Text -> Text
 extractDeclTypeSnippet result = extractedSnippet


### PR DESCRIPTION
Cleans up the main compiler pipeline in `Eclair.hs`, and introduces the `rock` build system for caching build artifacts.