### PR TITLE
Add a unique node ID to each AST node.

### DIFF
--- a/lib/Eclair/AST/Codegen.hs
+++ b/lib/Eclair/AST/Codegen.hs
@@ -70,8 +70,8 @@ data Term = VarTerm Id | LitTerm AST.Number
 
 toTerm :: AST.AST -> Term
 toTerm = \case
-  AST.Lit x -> LitTerm x
-  AST.Var x -> VarTerm x
+  AST.Lit _ x -> LitTerm x
+  AST.Var _ x -> VarTerm x
   -- TODO fix, no catch-all
   _ -> panic "Unknown pattern in 'toTerm'"
 
@@ -94,7 +94,7 @@ data Clause
 
 toClause :: AST.AST -> Clause
 toClause = \case
-  AST.Atom name values -> AtomClause name (map toTerm values)
+  AST.Atom _ name values -> AtomClause name (map toTerm values)
   _ -> panic "toClause: unsupported case"
 
 project :: Relation -> [Term] -> CodegenM RA

--- a/lib/Eclair/AST/IR.hs
+++ b/lib/Eclair/AST/IR.hs
@@ -13,6 +13,7 @@ module Eclair.AST.IR
   , Decl
   , Number
   , Type(..)
+  , NodeId(..)
   ) where
 
 import Control.Lens
@@ -20,6 +21,10 @@ import Data.Functor.Foldable.TH
 import Prettyprinter
 import Eclair.Id
 
+newtype NodeId
+  = NodeId
+  { unNodeId :: Int
+  } deriving (Eq, Ord, Show)
 
 type Number = Int
 
@@ -32,12 +37,12 @@ data Type
   deriving (Eq, Ord, Show)
 
 data AST
-  = Lit Number
-  | Var Id
-  | Atom Id [Value]
-  | Rule Id [Value] [Clause]
-  | DeclareType Id [Type]
-  | Module [Decl]
+  = Lit NodeId Number
+  | Var NodeId Id
+  | Atom NodeId Id [Value]
+  | Rule NodeId Id [Value] [Clause]
+  | DeclareType NodeId Id [Type]
+  | Module NodeId [Decl]
   deriving (Eq, Show)
 
 makePrisms ''AST

--- a/lib/Eclair/Parser.hs
+++ b/lib/Eclair/Parser.hs
@@ -7,16 +7,19 @@ module Eclair.Parser
   , Parser
   , ParseError
   , ParseErr
+  , Span
   ) where
 
 import Control.Monad.Fail
+import Control.Monad.ST
 import Data.Char
-import Data.Vector as V
 import Data.Void
 import Eclair.AST.IR
 import Eclair.Id
 import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import qualified Data.Vector as V
+import qualified Data.Vector.Mutable as MV
+import qualified Data.IntMap as M
 import qualified Data.Text.Read as TR
 import qualified Text.Megaparsec as P
 import qualified Text.Megaparsec.Char as P
@@ -24,26 +27,55 @@ import qualified Text.Megaparsec.Char.Lexer as L
 
 type ParseErr = Void
 type ParseError = P.ParseErrorBundle Text ParseErr
-type Parser = P.Parsec ParseErr Text
 
-parseFile :: FilePath -> IO (Either ParseError AST)
+data Span
+  = Span
+  { beginPos :: Int
+  , endPos :: Int
+  }
+
+type ParserState = (Int, IntMap Span)
+type Parser = P.ParsecT ParseErr Text (State ParserState)
+
+parseFile :: FilePath -> IO (Either ParseError (AST, IntMap Span))
 parseFile path = do
   contents <- readFileText path
   pure $ parseText path contents
 
-parseText :: FilePath -> Text -> Either ParseError AST
-parseText =
-  P.runParser astParser
+parseText :: FilePath -> Text -> Either ParseError (AST, IntMap Span)
+parseText path text =
+  snd <<$>> f (runState (P.runParserT astParser path text) (0, mempty))
+  where
+    f :: (Either a b, c) -> Either a (b, c)
+    f (m, c) = case m of
+      Left a -> Left a
+      Right b -> Right (b, c)
 
 printParseError :: ParseError -> IO ()
 printParseError err = putStrLn $ P.errorBundlePretty err
 
+freshNodeId :: Parser NodeId
+freshNodeId = do
+  nodeId <- gets (NodeId . fst)
+  modify $ first (+1)
+  pure nodeId
+
+withNodeId :: (NodeId -> Parser a) -> Parser a
+withNodeId f = do
+  nodeId <- freshNodeId
+  begin <- P.getOffset
+  parsed <- f nodeId
+  end <- P.getOffset
+  -- TODO: figure out if we can update a vector directly here without issues in ordering
+  modify $ second (M.insert (unNodeId nodeId) (Span begin end))
+  pure parsed
+
 astParser :: Parser AST
-astParser = do
+astParser = withNodeId $ \nodeId -> do
   whitespace
   decls <- declParser `P.endBy` whitespace
   P.eof
-  pure $ Module decls
+  pure $ Module nodeId decls
 
 declParser :: Parser AST
 declParser = do
@@ -57,38 +89,39 @@ typeParser = lexeme $
   U32 <$ P.chunk "u32"
 
 typedefParser :: Parser AST
-typedefParser = do
+typedefParser = withNodeId $ \nodeId -> do
   void $ lexeme $ P.chunk "@def"
   name <- lexeme identifier
   tys <- betweenParens $ typeParser `P.sepBy1` lexeme comma
   void $ P.char '.'
-  pure $ DeclareType name tys
+  pure $ DeclareType nodeId name tys
 
 data FactOrRule = FactType | RuleType
 
 factOrRuleParser :: Parser AST
-factOrRuleParser = do
+factOrRuleParser = withNodeId $ \nodeId -> do
   name <- lexeme identifier
   args <- lexeme $ betweenParens $ valueParser `P.sepBy1` comma
   declType <- lexeme $ (RuleType <$ P.chunk ":-") <|> (FactType <$ P.chunk ".")
   case declType of
     RuleType -> do
       body <- atomParser `P.sepBy1` comma <* period
-      pure $ Rule name args body
-    FactType -> pure $ Atom name args
+      pure $ Rule nodeId name args body
+    FactType -> pure $ Atom nodeId name args
   where period = lexeme $ P.char '.'
 
 comma :: Parser Char
 comma = lexeme $ P.char ','
 
 atomParser :: Parser AST
-atomParser = do
+atomParser = withNodeId $ \nodeId -> do
   name <- lexeme identifier
   args <- lexeme $ betweenParens $ valueParser `P.sepBy1` comma
-  pure $ Atom name args
+  pure $ Atom nodeId name args
+
 valueParser :: Parser AST
-valueParser =  Var <$> identifier
-           <|> Lit <$> number
+valueParser = withNodeId $ \nodeId ->
+  Var nodeId <$> identifier <|> Lit nodeId <$> number
 
 identifier :: Parser Id
 identifier = Id <$> do

--- a/lib/Eclair/TypeSystem.hs
+++ b/lib/Eclair/TypeSystem.hs
@@ -36,14 +36,14 @@ typeCheck ast
       & map (DuplicateTypeDeclaration . fst . head)
     typeDefs = extractTypeDefs ast
     typeErrors = execWriter $ flip cata ast $ \case
-      AtomF name args -> do
+      AtomF _ name args -> do
         case lookupType name of
           Nothing ->
             tell [UnknownAtom name]
           Just types ->
             checkArgCount name types args
 
-      RuleF name args clauses -> do
+      RuleF _ name args clauses -> do
         case lookupType name of
           Nothing ->
             tell [UnknownAtom name]
@@ -66,7 +66,7 @@ typeCheck ast
 
 extractTypeDefs :: AST -> [(Id, [Type])]
 extractTypeDefs = cata $ \case
-  DeclareTypeF name tys -> [(name, tys)]
+  DeclareTypeF _ name tys -> [(name, tys)]
   AtomF {} -> mempty
   RuleF {} -> mempty
   astf -> foldMap identity astf

--- a/tests/Test/Eclair/RA/IndexSelectionSpec.hs
+++ b/tests/Test/Eclair/RA/IndexSelectionSpec.hs
@@ -17,7 +17,7 @@ import qualified Data.Text as T
 idxSel :: FilePath -> IO IndexMap
 idxSel path = do
   let file = "tests/fixtures" </> path <.> "dl"
-  parseResult <- parseFile file
+  parseResult <- map fst <$> parseFile file
   case parseResult of
     Left err -> panic $ "Failed to parse " <> toText file <> "!"
     Right ast -> do

--- a/tests/Test/Eclair/RA/InterpreterSpec.hs
+++ b/tests/Test/Eclair/RA/InterpreterSpec.hs
@@ -21,7 +21,7 @@ type Record = [Number]
 
 interpret :: Text -> IO (M.Map Relation [Record])
 interpret txt = do
-  case parseText "<test>" txt of
+  case map fst $ parseText "<test>" txt of
     Left err -> do
       printParseError err
       panic "Failed to parse file."

--- a/tests/Test/Eclair/TypeSystemSpec.hs
+++ b/tests/Test/Eclair/TypeSystemSpec.hs
@@ -13,7 +13,7 @@ import NeatInterpolation
 
 tc :: Text -> Either [TypeError] TypeInfo
 tc code = do
-  let parseResult = parseText "<test>" code
+  let parseResult = map fst $ parseText "<test>" code
   case parseResult of
     Left _ -> panic "Failed to parse code!"
     Right ast -> typeCheck ast


### PR DESCRIPTION
This opens possibilities for Datalog-based analysis and optimizations,
where the unique ID helps map the original IR to Datalog facts.