### PR TITLE
Fix NoElem edge case during index selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The CHANGELOG is available on [Github](https://github.com/luc-tielen/souffle-has
 
 - Wildcards are now supported in rule bodies.
 
+### Fixed
+
+- Edgecase in index selection algorithm. The algorithm now does not take
+  `NoElem` variants into account.
+
 ## [0.0.1] - 2022-06-14
 
 ### Added

--- a/eclair-lang.cabal
+++ b/eclair-lang.cabal
@@ -37,6 +37,7 @@ library
       Eclair.AST.Lower
       Eclair.AST.Transforms
       Eclair.AST.Transforms.RemoveWildcards
+      Eclair.Comonads
       Eclair.EIR.Codegen
       Eclair.EIR.IR
       Eclair.EIR.Lower

--- a/lib/Eclair/Comonads.hs
+++ b/lib/Eclair/Comonads.hs
@@ -1,0 +1,32 @@
+module Eclair.Comonads
+  ( module Eclair.Comonads
+  ) where
+
+
+data Triple a b c
+  = Triple
+  { tFst :: a
+  , tSnd :: b
+  , tThd :: c
+  } deriving Functor
+
+instance Comonad (Triple a b) where
+  extract (Triple _ _ c) = c
+
+  duplicate (Triple a b c) =
+    Triple a b (Triple a b c)
+
+data Quad a b c d
+  = Quad
+  { qFirst :: a
+  , qSecond :: b
+  , qThird :: c
+  , qFourth :: d
+  } deriving Functor
+
+instance Comonad (Quad a b c) where
+  extract (Quad _ _ _ d) = d
+
+  duplicate (Quad a b c d) =
+    Quad a b c (Quad a b c d)
+

--- a/lib/Eclair/RA/Codegen.hs
+++ b/lib/Eclair/RA/Codegen.hs
@@ -292,7 +292,8 @@ withEndLabel end m = do
 idxFromConstraints :: Relation -> Alias -> [(Relation, Column)] -> CodegenM Index
 idxFromConstraints r a constraints = do
   getIndexForSearch <- idxSelector <$> getLowerState
-  tys <- fromJust . M.lookup r . typeEnv <$> getLowerState
+  let r' = stripIdPrefixes r
+  tys <- fromJust . M.lookup r' . typeEnv <$> getLowerState
   let columns
         -- NOTE: no constraints -> use index on all columns
         | null constraints = zipWith const [0..] tys

--- a/tests/Test/Eclair/RA/IndexSelectionSpec.hs
+++ b/tests/Test/Eclair/RA/IndexSelectionSpec.hs
@@ -127,3 +127,11 @@ spec = describe "Index selection" $ parallel $ do
                   , ("path", [[0,1]])
                   , ("edge", [[0,1]])
                   ]
+
+  it "does not use 'NoElem' constraints to compute indexes" $ do
+    idxSel "index_selection_should_only_check_for_equalities" `resultsIn`
+      toSelection [ ("delta_reachable", [[0,1]])
+                  , ("new_reachable", [[0,1]])
+                  , ("reachable", [[0,1]])
+                  , ("edge", [[0,1]])
+                  ]

--- a/tests/fixtures/index_selection_should_only_check_for_equalities.dl
+++ b/tests/fixtures/index_selection_should_only_check_for_equalities.dl
@@ -1,0 +1,9 @@
+@def edge(u32, u32).
+@def reachable(u32, u32).
+
+reachable(x, y) :-
+  edge(x, y).
+
+reachable(x, z) :-
+  edge(x, _),
+  reachable(_, z).


### PR DESCRIPTION
This commit fixes an issue I encountered when trying out the wildcards
feature. It generated an incorrect index for a relation since before it
used all `ColumnIndex` variants to see which rows were being accessed to
compute an index with.

Now the algorithm only takes into account the actual equality
constraints.