### PR TITLE
x86_64-linux: use shared libraries instead of static libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: cachix/install-nix-action@v15
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.5.1/install
+          install_url: https://releases.nixos.org/nix/nix-2.9.2/install
           extra_nix_config: |
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}

--- a/flake.lock
+++ b/flake.lock
@@ -29,6 +29,23 @@
         "type": "github"
       }
     },
+    "all-cabal-hashes-unpacked": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1663164766,
+        "narHash": "sha256-7ypfdEzJwfaQMQx9HV8B+r9BV7bN6iIO0lWhDy+8+0k=",
+        "owner": "commercialhaskell",
+        "repo": "all-cabal-hashes",
+        "rev": "ed701f5e64ece3e57efa4227243f9fb64f935253",
+        "type": "github"
+      },
+      "original": {
+        "owner": "commercialhaskell",
+        "ref": "current-hackage",
+        "repo": "all-cabal-hashes",
+        "type": "github"
+      }
+    },
     "brittany-01312": {
       "flake": false,
       "locked": {
@@ -92,8 +109,8 @@
     },
     "ds_2": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_5"
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1650900878,
@@ -112,8 +129,8 @@
     },
     "ds_3": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
-        "nixpkgs": "nixpkgs_6"
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1650900878,
@@ -128,6 +145,18 @@
         "ref": "master",
         "repo": "devshell",
         "type": "github"
+      }
+    },
+    "entropy": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-Oj0vftbS7Pau7OzdMrzRPghqwEiimwQbt0w59cMcH98=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/entropy-0.4.1.10/entropy-0.4.1.10.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/entropy-0.4.1.10/entropy-0.4.1.10.tar.gz"
       }
     },
     "flake-compat": {
@@ -163,11 +192,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -177,36 +206,6 @@
       }
     },
     "flake-utils_3": {
-      "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_5": {
       "locked": {
         "lastModified": 1642700792,
         "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
@@ -221,7 +220,7 @@
         "type": "github"
       }
     },
-    "flake-utils_6": {
+    "flake-utils_4": {
       "locked": {
         "lastModified": 1642700792,
         "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
@@ -308,6 +307,18 @@
         "type": "github"
       }
     },
+    "ghc-check": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-pmmQMrk6X00+zbsstV49w/Es9+V9gssrXzJoub2ReEs=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/ghc-check-0.5.0.8/ghc-check-0.5.0.8.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/ghc-check-0.5.0.8/ghc-check-0.5.0.8.tar.gz"
+      }
+    },
     "ghc-exactprint": {
       "flake": false,
       "locked": {
@@ -335,11 +346,11 @@
     "gitignore": {
       "flake": false,
       "locked": {
-        "lastModified": 1646480205,
-        "narHash": "sha256-kekOlTlu45vuK2L9nq8iVN17V3sB0WWPqTTW3a2SQG0=",
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "bff2832ec341cf30acb3a4d3e2e7f1f7b590116a",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
         "type": "github"
       },
       "original": {
@@ -351,13 +362,25 @@
     "hie-bios": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-5RqspT27rb/tMBwrKr4VfSSbq0+c0LMNuaKlTun0Kkk=",
+        "narHash": "sha256-KLAg++tO9lCOn7R/cSN2wLbrhpeBOOmeTEh7auIbUNk=",
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hie-bios-0.9.1/hie-bios-0.9.1.tar.gz"
+        "url": "https://hackage.haskell.org/package/hie-bios-0.11.0/hie-bios-0.11.0.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hie-bios-0.9.1/hie-bios-0.9.1.tar.gz"
+        "url": "https://hackage.haskell.org/package/hie-bios-0.11.0/hie-bios-0.11.0.tar.gz"
+      }
+    },
+    "hiedb": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-Ny9Ya7Y8GGdBh8r2cryQfK4XZj2dIrYQpaB8dTNQ3KI=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/hiedb-0.4.2.0/hiedb-0.4.2.0.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/hiedb-0.4.2.0/hiedb-0.4.2.0.tar.gz"
       }
     },
     "hlint": {
@@ -387,37 +410,37 @@
     "hls": {
       "inputs": {
         "aeson-1520": "aeson-1520",
+        "all-cabal-hashes-unpacked": "all-cabal-hashes-unpacked",
         "brittany-01312": "brittany-01312",
         "constraints-extras": "constraints-extras",
+        "entropy": "entropy",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils_2",
         "fourmolu": "fourmolu",
         "fourmolu-0300": "fourmolu-0300",
+        "ghc-check": "ghc-check",
         "ghc-exactprint": "ghc-exactprint",
         "ghc-exactprint-150": "ghc-exactprint-150",
         "gitignore": "gitignore",
         "hie-bios": "hie-bios",
+        "hiedb": "hiedb",
         "hlint": "hlint",
         "hlint-34": "hlint-34",
         "implicit-hie-cradle": "implicit-hie-cradle",
         "lsp": "lsp",
         "lsp-test": "lsp-test",
         "lsp-types": "lsp-types",
-        "myst-parser": "myst-parser",
         "nixpkgs": "nixpkgs_2",
-        "poetry2nix": "poetry2nix",
-        "pre-commit-hooks": "pre-commit-hooks",
         "ptr-poker": "ptr-poker",
         "retrie": "retrie",
-        "sphinx_rtd_theme": "sphinx_rtd_theme",
-        "stylish-haskell-01220": "stylish-haskell-01220"
+        "stylish-haskell": "stylish-haskell"
       },
       "locked": {
-        "lastModified": 1653778781,
-        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
+        "lastModified": 1665336737,
+        "narHash": "sha256-uACGk1k0kCH6QSFyZ54xKWN2TOUYfivJ+gMEcKsill0=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
+        "rev": "050497a19f0c40936169b39506fce7c007595b83",
         "type": "github"
       },
       "original": {
@@ -463,54 +486,37 @@
     "lsp": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-OcyNHNRh9j5nbJ8SjaNAWIEKuixAJlA7+vTimFY0c2c=",
+        "narHash": "sha256-g5R34SVz0kRD5zpODNsaaaIJOHty10cTS6ZDPi4s8pc=",
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/lsp-1.4.0.0/lsp-1.4.0.0.tar.gz"
+        "url": "https://hackage.haskell.org/package/lsp-1.6.0.0/lsp-1.6.0.0.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/lsp-1.4.0.0/lsp-1.4.0.0.tar.gz"
+        "url": "https://hackage.haskell.org/package/lsp-1.6.0.0/lsp-1.6.0.0.tar.gz"
       }
     },
     "lsp-test": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-IOmbQH6tKdu9kAyirvLx6xFS2N+/tbs6vZn0mNGm3No=",
+        "narHash": "sha256-HhFAdNvmnnnCzsKfTWbqUyTFrCfq1n6pGKfk2R0fcUc=",
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/lsp-test-0.14.0.2/lsp-test-0.14.0.2.tar.gz"
+        "url": "https://hackage.haskell.org/package/lsp-test-0.14.1.0/lsp-test-0.14.1.0.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/lsp-test-0.14.0.2/lsp-test-0.14.0.2.tar.gz"
+        "url": "https://hackage.haskell.org/package/lsp-test-0.14.1.0/lsp-test-0.14.1.0.tar.gz"
       }
     },
     "lsp-types": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-HGg4upgirM6/px+vflY5S0Y79gAIDpl32Ad9mbbzTdU=",
+        "narHash": "sha256-QSixsrCvsWlckG/LLF1z8LsHhqaXxVAxOPIA1NxjVT4=",
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/lsp-types-1.4.0.1/lsp-types-1.4.0.1.tar.gz"
+        "url": "https://hackage.haskell.org/package/lsp-types-1.6.0.0/lsp-types-1.6.0.0.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/lsp-types-1.4.0.1/lsp-types-1.4.0.1.tar.gz"
-      }
-    },
-    "myst-parser": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650933355,
-        "narHash": "sha256-Osd3urvH1bn9w/6sAMyLKHO7gxuYePpGJ9y8ReBfp4E=",
-        "owner": "smunix",
-        "repo": "MyST-Parser",
-        "rev": "57d0d78169a0e157406c35df951bdffdf94b4f9b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "smunix",
-        "ref": "fix.hls-docutils",
-        "repo": "MyST-Parser",
-        "type": "github"
+        "url": "https://hackage.haskell.org/package/lsp-types-1.6.0.0/lsp-types-1.6.0.0.tar.gz"
       }
     },
     "nixpkgs": {
@@ -531,11 +537,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1650792148,
-        "narHash": "sha256-n1MZSZIzvP70BJ56tV8GwQ5L0wHt/nTH9UkF5HTGB/4=",
+        "lastModified": 1663112159,
+        "narHash": "sha256-31rjPhB6Hj1QoqLvFSULFf9Z/6z05vR0KrLGYvr9w0M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ab83c5d70528f1edc7080dead3a5dee61797b3ff",
+        "rev": "78bce1608960b994405f3696ba086ba1d63654e9",
         "type": "github"
       },
       "original": {
@@ -546,35 +552,6 @@
       }
     },
     "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1650933476,
-        "narHash": "sha256-kBefFyATME/AGGFMudAltOeKYnSc3YDOI0YgDjjIhzw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7deb7b084d6959f4076bcf0ff4aa0a120f1d31ca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1645655918,
-        "narHash": "sha256-ZfbEFRW7o237+A1P7eTKhXje435FCAoe0blj2n20Was=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "77a7a4197740213879b9a1d2e1788c6c8ade4274",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_5": {
       "locked": {
         "lastModified": 1643381941,
         "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
@@ -590,7 +567,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1643381941,
         "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
@@ -635,45 +612,6 @@
         "owner": "nixos",
         "ref": "master",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "poetry2nix": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1650693998,
-        "narHash": "sha256-rypGV9HND1VsR/DEtD4O3cPcwCJVfIiTKvEbYskQSqg=",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "8cfd980262181bd3ef15899708ceeb2e3f33958b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "master",
-        "repo": "poetry2nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_4"
-      },
-      "locked": {
-        "lastModified": 1649054408,
-        "narHash": "sha256-wz8AH7orqUE4Xog29WMTqOYBs0DMj2wFM8ulrTRVgz0=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "e5e7b3b542e7f4f96967966a943d7e1c07558042",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
@@ -733,33 +671,16 @@
         "type": "github"
       }
     },
-    "sphinx_rtd_theme": {
+    "stylish-haskell": {
       "flake": false,
       "locked": {
-        "lastModified": 1628276861,
-        "narHash": "sha256-fzqi0QfDSiN8YXtAiWXIoOlyHZQI4V32uOKZjPfWeWY=",
-        "owner": "readthedocs",
-        "repo": "sphinx_rtd_theme",
-        "rev": "34f81daaf52466366c80003db293d50075c1b896",
-        "type": "github"
-      },
-      "original": {
-        "owner": "readthedocs",
-        "repo": "sphinx_rtd_theme",
-        "rev": "34f81daaf52466366c80003db293d50075c1b896",
-        "type": "github"
-      }
-    },
-    "stylish-haskell-01220": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-uQIvhz/xRbKLHe9et+tHUVE9To5vt1Pz3+vvDEqJaLI=",
+        "narHash": "sha256-oZSR5UQ+ieMFRq7MvL0sJqOblMk74awvcepuT+JHYtA=",
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/stylish-haskell-0.12.2.0/stylish-haskell-0.12.2.0.tar.gz"
+        "url": "https://hackage.haskell.org/package/stylish-haskell-0.14.2.0/stylish-haskell-0.14.2.0.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/stylish-haskell-0.12.2.0/stylish-haskell-0.12.2.0.tar.gz"
+        "url": "https://hackage.haskell.org/package/stylish-haskell-0.14.2.0/stylish-haskell-0.14.2.0.tar.gz"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -110,7 +110,7 @@
     "ds_2": {
       "inputs": {
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1650900878,
@@ -513,6 +513,19 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1665243495,
+        "narHash": "sha256-ql3V30h8VIu5Un14ekQ4YwcXDhOuToBTATtsMZjpf1U=",
+        "path": "/nix/store/ljjaycxhhp83rpf9z26n2nf1c1rd4rpm-source",
+        "rev": "b504f7c3e194aeec1e4891491cac3bc59875b033",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1643381941,
         "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
         "owner": "NixOS",
@@ -540,6 +553,25 @@
         "owner": "nixos",
         "ref": "master",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nu": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1665450992,
+        "narHash": "sha256-PIOVcabas+OUeQdYA0xC0vqiYCQCsXXYwn7nPxAGp2o=",
+        "owner": "smunix",
+        "repo": "nix-utils",
+        "rev": "98dec8fa8880275a6f9096617627335edc6266d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "smunix",
+        "ref": "main",
+        "repo": "nix-utils",
         "type": "github"
       }
     },
@@ -576,6 +608,7 @@
         "hls": "hls",
         "llvm-cg": "llvm-cg",
         "nf": "nf",
+        "nu": "nu",
         "shs": "shs"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -471,15 +471,14 @@
       "locked": {
         "lastModified": 1664570718,
         "narHash": "sha256-ySuqcpGH4FpdTDl8MR/IxRWbYYQDQPBVyLgc0nzxLMc=",
-        "owner": "luc-tielen",
+        "owner": "smunix",
         "repo": "llvm-codegen",
         "rev": "83306c9da879b80be674ef7cf910aaf158160b69",
         "type": "github"
       },
       "original": {
-        "owner": "luc-tielen",
+        "owner": "smunix",
         "repo": "llvm-codegen",
-        "rev": "83306c9da879b80be674ef7cf910aaf158160b69",
         "type": "github"
       }
     },
@@ -517,6 +516,22 @@
       "original": {
         "type": "tarball",
         "url": "https://hackage.haskell.org/package/lsp-types-1.6.0.0/lsp-types-1.6.0.0.tar.gz"
+      }
+    },
+    "nf": {
+      "locked": {
+        "lastModified": 1661201956,
+        "narHash": "sha256-RizGJH/buaw9A2+fiBf9WnXYw4LZABB5kMAZIEE5/T8=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3b821578685d661a10b563cba30b1861eec05748",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "master",
+        "repo": "nix-filter",
+        "type": "github"
       }
     },
     "nixpkgs": {
@@ -647,6 +662,7 @@
         "fu": "fu",
         "hls": "hls",
         "llvm-cg": "llvm-cg",
+        "nf": "nf",
         "shs": "shs"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -127,26 +127,6 @@
         "type": "github"
       }
     },
-    "ds_3": {
-      "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_4"
-      },
-      "locked": {
-        "lastModified": 1650900878,
-        "narHash": "sha256-qhNncMBSa9STnhiLfELEQpYC1L4GrYHNIzyCZ/pilsI=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "d97df53b5ddaa1cfbea7cddbd207eb2634304733",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "master",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "entropy": {
       "flake": false,
       "locked": {
@@ -220,21 +200,6 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
-      "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "fourmolu": {
       "flake": false,
       "locked": {
@@ -276,22 +241,6 @@
       }
     },
     "fu_2": {
-      "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "master",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "fu_3": {
       "locked": {
         "lastModified": 1652372896,
         "narHash": "sha256-lURGussfF3mGrFPQT3zgW7+RC0pBhbHzco0C7I+ilow=",
@@ -463,21 +412,17 @@
       }
     },
     "llvm-cg": {
-      "inputs": {
-        "ds": "ds_2",
-        "fu": "fu_2",
-        "np": "np"
-      },
+      "flake": false,
       "locked": {
-        "lastModified": 1664570718,
-        "narHash": "sha256-ySuqcpGH4FpdTDl8MR/IxRWbYYQDQPBVyLgc0nzxLMc=",
-        "owner": "smunix",
+        "lastModified": 1665337816,
+        "narHash": "sha256-vyewb0Qb49SQ8T9kS0gyFq6050NshgiKjPW0zaZKtAc=",
+        "owner": "luc-tielen",
         "repo": "llvm-codegen",
-        "rev": "83306c9da879b80be674ef7cf910aaf158160b69",
+        "rev": "b42e6542a13337b8b8c80a03f3f3ff36c320d056",
         "type": "github"
       },
       "original": {
-        "owner": "smunix",
+        "owner": "luc-tielen",
         "repo": "llvm-codegen",
         "type": "github"
       }
@@ -582,39 +527,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1643381941,
-        "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5efc8ca954272c4376ac929f4c5ffefcc20551d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "np": {
-      "locked": {
-        "lastModified": 1651725581,
-        "narHash": "sha256-5KFbtrJIZ/KCdgo92qC8CYmOxcb2n+yOCeddCGkzviA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2ab8e66328a9979ce69ed6d48a7e0fa7de5d42cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "haskell-updates",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "np_2": {
       "locked": {
         "lastModified": 1652527621,
         "narHash": "sha256-hHqY6n8nAKk8St2+BDkCOvXaUQSeN8GHgQR1jDuc+to=",
@@ -668,9 +581,9 @@
     },
     "shs": {
       "inputs": {
-        "ds": "ds_3",
-        "fu": "fu_3",
-        "np": "np_2"
+        "ds": "ds_2",
+        "fu": "fu_2",
+        "np": "np"
       },
       "locked": {
         "lastModified": 1653686988,

--- a/flake.lock
+++ b/flake.lock
@@ -463,7 +463,7 @@
         "url": "https://hackage.haskell.org/package/lsp-types-1.6.0.0/lsp-types-1.6.0.0.tar.gz"
       }
     },
-    "nf": {
+    "nix-filter": {
       "locked": {
         "lastModified": 1661201956,
         "narHash": "sha256-RizGJH/buaw9A2+fiBf9WnXYw4LZABB5kMAZIEE5/T8=",
@@ -474,7 +474,6 @@
       },
       "original": {
         "owner": "numtide",
-        "ref": "master",
         "repo": "nix-filter",
         "type": "github"
       }
@@ -558,14 +557,15 @@
     },
     "nu": {
       "inputs": {
+        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1665450992,
-        "narHash": "sha256-PIOVcabas+OUeQdYA0xC0vqiYCQCsXXYwn7nPxAGp2o=",
+        "lastModified": 1665458179,
+        "narHash": "sha256-PzCYFrA+y63hrXu5wFdFruY1a5EKzgqPL92eTvGjvzE=",
         "owner": "smunix",
         "repo": "nix-utils",
-        "rev": "98dec8fa8880275a6f9096617627335edc6266d6",
+        "rev": "c0b0b55939884cc695ecae6db37eaef9cbaf4748",
         "type": "github"
       },
       "original": {
@@ -607,7 +607,6 @@
         "fu": "fu",
         "hls": "hls",
         "llvm-cg": "llvm-cg",
-        "nf": "nf",
         "nu": "nu",
         "shs": "shs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     # np.url = "github:nixos/nixpkgs?ref=haskell-updates";
     fu.url = "github:numtide/flake-utils?ref=master";
     ds.url = "github:numtide/devshell?ref=master";
-    nf.url = "github:numtide/nix-filter?ref=master";
     nu.url = "github:smunix/nix-utils?ref=main";
     hls.url = "github:haskell/haskell-language-server?ref=master";
     shs.url =
@@ -19,7 +18,7 @@
       "github:luc-tielen/diagnose?rev=d58752f062c105ec0f8831357f3c688965e13add";
     diagnose.flake = false;
   };
-  outputs = { self, fu, nf, nu, ds, shs, llvm-cg, ... }@inputs:
+  outputs = { self, fu, nu, ds, shs, llvm-cg, ... }@inputs:
     let
       # Use the same nixpkgs as souffle-haskell, to avoid weird issues with multiple versions of Haskell packages.
       np = shs.inputs.np;
@@ -28,106 +27,112 @@
     with nu.lib;
     eachSystem [ "x86_64-linux" ] (system:
       let
-        ghcVersion = "902";
+        ghcVersion = 902;
         llvmVersion = 14;
-        version = "${ghcVersion}.${substring 0 8 self.lastModifiedDate}.${
+        version =
+          "${toString ghcVersion}.${substring 0 8 self.lastModifiedDate}.${
             self.shortRev or "dirty"
           }";
         config = { };
-        overlay = final: _:
+        overlays.default = final: _:
           let
+            mkCabal2nix = mkCabal {
+              inherit ghcVersion;
+              packages = final;
+              mkVersion = v:
+                "${v}.${substring 0 8 self.lastModifiedDate}.${
+                  self.shortRev or "dirty"
+                }";
+            };
             llvmPackages = rec {
               llvmPkgs = final."llvmPackages_${toString llvmVersion}";
               inherit (llvmPkgs) llvm libllvm bintools-unwrapped;
             };
             haskellPackages =
-              final.haskell.packages."ghc${ghcVersion}".override {
+              final.haskell.packages."ghc${toString ghcVersion}".override {
                 overrides = hf: hp:
                   with final.haskell.lib; rec {
                     inherit (shs.packages."${system}") souffle-haskell;
 
-                    llvm-codegen = addExtraLibraries ( haskellSharedLibExe final
-                        (appendConfigureFlags
-                          ((hf.callCabal2nix "llvm-codegen" (with nf.lib;
-                            filter {
-                              root = inputs.llvm-cg;
-                              exclude = [ ("Setup.hs") ];
-                            }) {
-                              llvm-config = llvmPackages.llvm;
-                            }).overrideAttrs
-                            (old: { version = "${old.version}-${version}"; }))
-                          [ "--ghc-option=-optl=-lLLVM" ]))
-                      [ llvmPackages.llvm.dev ];
+                    llvm-codegen = mkCabal2nix {
+                      name = "llvm-codegen";
+                      source = inputs.llvm-cg;
+                      dependencies = { llvm-config = llvmPackages.llvm.dev; };
+                      configureFlags = [ "--ghc-option=-optl=-lLLVM" ];
+                      extraLibraries = [ llvmPackages.llvm.dev ];
+                    };
 
-                    algebraic-graphs = with hf;
-                      dontCheck
-                      (callCabal2nix "algebraic-graphs" (inputs.alga) { });
+                    algebraic-graphs = dontCheck (mkCabal2nix {
+                      name = "algebraic-graphs";
+                      source = inputs.alga;
+                      doLibraryProfiling = enableLibraryProfiling;
+                    });
 
-                    dependent-hashmap = with hf;
-                      unmarkBroken (dontCheck hp.dependent-hashmap);
+                    dependent-hashmap = unmarkBroken (dontCheck (mkCabal2nix {
+                      name = "dependent-hashmap";
+                      source = inputs.alga;
+                    }));
 
                     diagnose =
                       hf.callCabal2nixWithOptions "diagnose" (inputs.diagnose)
                       "-fmegaparsec-compat" { };
 
-                    eclair-lang = with hf;
-                      with final.haskell.lib;
-                      addExtraLibraries (
-                          haskellSharedLibExe final (appendConfigureFlags
-                            ((callCabal2nix "eclair-lang" ./. { }).overrideAttrs
-                              (o: {
-                                version = "${o.version}.${version}";
-                                checkPhase = ''
-                                  runHook preCheck
-                                  DATALOG_DIR="${o.src}/cbits/" SOUFFLE_BIN="${pkgs.souffle}/bin/souffle" ./Setup test
-                                  runHook postCheck
-                                '';
-                              })) [ "--ghc-option=-optl=-lLLVM" ]))
-                      [ llvmPackages.llvm.dev ];
+                    eclair-lang = mkCabal2nix {
+                      name = "eclair-lang";
+                      source = self;
+                      configureFlags = [ "--ghc-option=-optl=-lLLVM" ];
+                      haskellPackages = hf;
+                      extraLibraries = [ llvmPackages.llvm.dev ];
+                      overrideAttrs = o: {
+                        checkPhase = ''
+                          runHook preCheck
+                          DATALOG_DIR="${self}/cbits/" SOUFFLE_BIN="${pkgs.souffle}/bin/souffle" ./Setup test
+                          runHook postCheck
+                        '';
+                      };
+                    };
                   };
               };
           in { inherit haskellPackages llvmPackages; };
         pkgs = import np {
           inherit system config;
-          overlays = [
-            ds.overlay
-            shs.overlay."${system}"
-            overlay
-          ];
+          overlays = [ ds.overlay shs.overlay."${system}" overlays.default ];
         };
-      in with pkgs.lib; rec {
-        inherit overlay;
-        packages = { inherit (pkgs.haskellPackages) eclair-lang; };
-        defaultPackage = packages.eclair-lang;
-        devShell = pkgs.devshell.mkShell {
-          name = "ECLAIR-LANG";
-          imports = [ (pkgs.devshell.importTOML ./devshell.toml) ];
-          packages = with pkgs;
-            with haskellPackages; [
-              souffle
-              pkgs.ghcid
-              llvmPackages.libllvm
-              llvmPackages.llvm.dev
-              llvmPackages.bintools-unwrapped
-              (ghcWithPackages (p:
-                with p; [
-                  algebraic-graphs
-                  cabal-install
-                  ghc
-                  hsc2hs
-                  hpack
-                  haskell-language-server
-                  hlint
-                  hspec-discover
-                  llvm-codegen
-                  souffle-haskell
-                ]))
-            ];
-          # Next line always sets DATALOG_DIR so souffle can find the datalog files in interpreted mode.
-          env = [{
-            name = "DATALOG_DIR";
-            value = "cbits/";
-          }];
+        packages = rec {
+          inherit (pkgs.haskellPackages) eclair-lang;
+          default = eclair-lang;
         };
-      });
+        devShells = rec {
+          default = pkgs.devshell.mkShell {
+            name = "ECLAIR-LANG";
+            imports = [ (pkgs.devshell.importTOML ./devshell.toml) ];
+            packages = with pkgs;
+              with haskellPackages; [
+                souffle
+                pkgs.ghcid
+                llvmPackages.libllvm
+                llvmPackages.llvm.dev
+                llvmPackages.bintools-unwrapped
+                (ghcWithPackages (p:
+                  with p; [
+                    algebraic-graphs
+                    cabal-install
+                    ghc
+                    hsc2hs
+                    hpack
+                    haskell-language-server
+                    hlint
+                    hspec-discover
+                    llvm-codegen
+                    souffle-haskell
+                  ]))
+              ];
+            # Next line always sets DATALOG_DIR so souffle can find the datalog files in interpreted mode.
+            env = [{
+              name = "DATALOG_DIR";
+              value = "cbits/";
+            }];
+          };
+        };
+      in { inherit overlays packages devShells; });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,106 +5,128 @@
     # np.url = "github:nixos/nixpkgs?ref=haskell-updates";
     fu.url = "github:numtide/flake-utils?ref=master";
     ds.url = "github:numtide/devshell?ref=master";
+    nf.url = "github:numtide/nix-filter?ref=master";
     hls.url = "github:haskell/haskell-language-server?ref=master";
     shs.url =
       "github:luc-tielen/souffle-haskell?rev=c46d0677e4bc830df89ec1de2396c562eb9d86d3";
-    llvm-cg.url =
-      "github:luc-tielen/llvm-codegen?rev=83306c9da879b80be674ef7cf910aaf158160b69";
+    llvm-cg.url = "github:smunix/llvm-codegen?fix.x86_64-linux";
     alga.url =
       "github:snowleopard/alga?rev=75de41a4323ab9e58ca49dbd78b77f307b189795";
     alga.flake = false;
-    diagnose.url = "github:luc-tielen/diagnose?rev=d58752f062c105ec0f8831357f3c688965e13add";
+    diagnose.url =
+      "github:luc-tielen/diagnose?rev=d58752f062c105ec0f8831357f3c688965e13add";
     diagnose.flake = false;
   };
-  outputs = { self, fu, ds, shs, llvm-cg, ... }@inputs:
+  outputs = { self, fu, nf, ds, shs, llvm-cg, ... }@inputs:
     let
       # Use the same nixpkgs as souffle-haskell, to avoid weird issues with multiple versions of Haskell packages.
       np = shs.inputs.np;
-    in
-      with np.lib;
-      with fu.lib;
-      eachSystem [ "x86_64-linux" ] (system:
-        let
-          ghcVersion = "902";
-          llvmVersion = 14;
-          version = "${ghcVersion}.${substring 0 8 self.lastModifiedDate}.${
-              self.shortRev or "dirty"
-            }";
-          config = {};
-          overlay = final: _:
-            let
-              wasmPackages = rec {
-                llvmPkgs = final."llvmPackages_${toString llvmVersion}";
-                inherit (llvmPkgs) llvm libllvm bintools-unwrapped;
+    in with np.lib;
+    with fu.lib;
+    eachSystem [ "x86_64-linux" ] (system:
+      let
+        ghcVersion = "902";
+        llvmVersion = 14;
+        version = "${ghcVersion}.${substring 0 8 self.lastModifiedDate}.${
+            self.shortRev or "dirty"
+          }";
+        config = { };
+        overlay = final: _:
+          let
+            wasmPackages = rec {
+              llvmPkgs = final."llvmPackages_${toString llvmVersion}";
+              inherit (llvmPkgs) llvm libllvm bintools-unwrapped;
+            };
+            haskellPackages =
+              final.haskell.packages."ghc${ghcVersion}".override {
+                overrides = hf: hp:
+                  with final.haskell.lib; rec {
+                    inherit (shs.packages."${system}") souffle-haskell;
+
+                    llvm-codegen = addExtraLibraries (enableSharedExecutables
+                      (disableStaticLibraries (disableLibraryProfiling
+                        (enableSharedLibraries (appendConfigureFlags
+                          ((hf.callCabal2nix "llvm-codegen" (with nf.lib;
+                            filter {
+                              root = inputs.llvm-cg;
+                              exclude = [ ("Setup.hs") ];
+                            }) {
+                              llvm-config = wasmPackages.llvm;
+                            }).overrideAttrs
+                            (old: { version = "${old.version}-${version}"; }))
+                          [ "--ghc-option=-optl=-lLLVM" ])))))
+                      [ wasmPackages.llvm.dev ];
+
+                    algebraic-graphs = with hf;
+                      dontCheck
+                      (callCabal2nix "algebraic-graphs" (inputs.alga) { });
+
+                    dependent-hashmap = with hf;
+                      unmarkBroken (dontCheck hp.dependent-hashmap);
+
+                    diagnose =
+                      hf.callCabal2nixWithOptions "diagnose" (inputs.diagnose)
+                      "-fmegaparsec-compat" { };
+
+                    eclair-lang = with hf;
+                      with final.haskell.lib;
+                      addExtraLibraries (disableLibraryProfiling
+                        (disableStaticLibraries (enableSharedExecutables
+                          (enableSharedLibraries (appendConfigureFlags
+                            ((callCabal2nix "eclair-lang" ./. { }).overrideAttrs
+                              (o: {
+                                version = "${o.version}.${version}";
+                                checkPhase = ''
+                                  runHook preCheck
+                                  DATALOG_DIR="${o.src}/cbits/" SOUFFLE_BIN="${pkgs.souffle}/bin/souffle" ./Setup test
+                                  runHook postCheck
+                                '';
+                              })) [ "--ghc-option=-optl=-lLLVM" ])))))
+                      [ wasmPackages.llvm.dev ];
+                  };
               };
-              haskellPackages =
-                final.haskell.packages."ghc${ghcVersion}".override {
-                  overrides = hf: hp:
-                    with final.haskell.lib; rec {
-                      inherit (shs.packages."${system}") souffle-haskell;
-                      inherit (llvm-cg.packages."${system}") llvm-codegen;
-
-                      algebraic-graphs = with hf;
-                        dontCheck
-                        (callCabal2nix "algebraic-graphs" (inputs.alga) { });
-
-                      dependent-hashmap = with hf;
-                        unmarkBroken (dontCheck hp.dependent-hashmap);
-
-                      diagnose = hf.callCabal2nixWithOptions "diagnose" (inputs.diagnose) "-fmegaparsec-compat" {};
-
-                      eclair-lang = with hf;
-                        (callCabal2nix "eclair-lang" ./. { }).overrideAttrs
-                        (o: {
-                          version = "${o.version}.${version}";
-                          checkPhase = ''
-                          runHook preCheck
-                          DATALOG_DIR="${o.src}/cbits/" SOUFFLE_BIN="${pkgs.souffle}/bin/souffle" ./Setup test
-                          runHook postCheck
-                          '';
-                        });
-                    };
-                };
-            in { inherit haskellPackages wasmPackages; };
-          pkgs = import np {
-            inherit system config;
-            overlays = [
-              ds.overlay
-              shs.overlay."${system}"
-              llvm-cg.overlay."${system}"
-              overlay
+          in { inherit haskellPackages wasmPackages; };
+        pkgs = import np {
+          inherit system config;
+          overlays = [
+            ds.overlay
+            shs.overlay."${system}"
+            overlay
+          ];
+        };
+      in with pkgs.lib; rec {
+        inherit overlay;
+        packages = { inherit (pkgs.haskellPackages) eclair-lang; };
+        defaultPackage = packages.eclair-lang;
+        devShell = pkgs.devshell.mkShell {
+          name = "ECLAIR-LANG";
+          imports = [ (pkgs.devshell.importTOML ./devshell.toml) ];
+          packages = with pkgs;
+            with haskellPackages; [
+              souffle
+              pkgs.ghcid
+              wasmPackages.libllvm
+              wasmPackages.llvm.dev
+              wasmPackages.bintools-unwrapped
+              (ghcWithPackages (p:
+                with p; [
+                  algebraic-graphs
+                  cabal-install
+                  ghc
+                  hsc2hs
+                  hpack
+                  haskell-language-server
+                  hlint
+                  hspec-discover
+                  llvm-codegen
+                  souffle-haskell
+                ]))
             ];
-          };
-        in with pkgs.lib; rec {
-          inherit overlay;
-          packages = { inherit (pkgs.haskellPackages) eclair-lang; };
-          defaultPackage = packages.eclair-lang;
-          devShell = pkgs.devshell.mkShell {
-            name = "ECLAIR-LANG";
-            imports = [ (pkgs.devshell.importTOML ./devshell.toml) ];
-            packages = with pkgs;
-              with haskellPackages; [
-                souffle
-                pkgs.ghcid
-                wasmPackages.libllvm
-                wasmPackages.llvm.dev
-                wasmPackages.bintools-unwrapped
-                (ghcWithPackages (p:
-                  with p; [
-                    algebraic-graphs
-                    cabal-install
-                    ghc
-                    hsc2hs
-                    hpack
-                    haskell-language-server
-                    hlint
-                    hspec-discover
-                    llvm-codegen
-                    souffle-haskell
-                  ]))
-              ];
-            # Next line always sets DATALOG_DIR so souffle can find the datalog files in interpreted mode.
-            env = [{ name = "DATALOG_DIR"; value = "cbits/"; }];
-          };
-        });
+          # Next line always sets DATALOG_DIR so souffle can find the datalog files in interpreted mode.
+          env = [{
+            name = "DATALOG_DIR";
+            value = "cbits/";
+          }];
+        };
+      });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,8 @@
     hls.url = "github:haskell/haskell-language-server?ref=master";
     shs.url =
       "github:luc-tielen/souffle-haskell?rev=c46d0677e4bc830df89ec1de2396c562eb9d86d3";
-    llvm-cg.url = "github:smunix/llvm-codegen?fix.x86_64-linux";
+    llvm-cg.url = "github:luc-tielen/llvm-codegen";
+    llvm-cg.flake = false;
     alga.url =
       "github:snowleopard/alga?rev=75de41a4323ab9e58ca49dbd78b77f307b189795";
     alga.flake = false;
@@ -33,7 +34,7 @@
         config = { };
         overlay = final: _:
           let
-            wasmPackages = rec {
+            llvmPackages = rec {
               llvmPkgs = final."llvmPackages_${toString llvmVersion}";
               inherit (llvmPkgs) llvm libllvm bintools-unwrapped;
             };
@@ -51,11 +52,11 @@
                               root = inputs.llvm-cg;
                               exclude = [ ("Setup.hs") ];
                             }) {
-                              llvm-config = wasmPackages.llvm;
+                              llvm-config = llvmPackages.llvm;
                             }).overrideAttrs
                             (old: { version = "${old.version}-${version}"; }))
                           [ "--ghc-option=-optl=-lLLVM" ])))))
-                      [ wasmPackages.llvm.dev ];
+                      [ llvmPackages.llvm.dev ];
 
                     algebraic-graphs = with hf;
                       dontCheck
@@ -82,10 +83,10 @@
                                   runHook postCheck
                                 '';
                               })) [ "--ghc-option=-optl=-lLLVM" ])))))
-                      [ wasmPackages.llvm.dev ];
+                      [ llvmPackages.llvm.dev ];
                   };
               };
-          in { inherit haskellPackages wasmPackages; };
+          in { inherit haskellPackages llvmPackages; };
         pkgs = import np {
           inherit system config;
           overlays = [
@@ -105,9 +106,9 @@
             with haskellPackages; [
               souffle
               pkgs.ghcid
-              wasmPackages.libllvm
-              wasmPackages.llvm.dev
-              wasmPackages.bintools-unwrapped
+              llvmPackages.libllvm
+              llvmPackages.llvm.dev
+              llvmPackages.bintools-unwrapped
               (ghcWithPackages (p:
                 with p; [
                   algebraic-graphs

--- a/flake.nix
+++ b/flake.nix
@@ -68,10 +68,7 @@
                       doLibraryProfiling = enableLibraryProfiling;
                     });
 
-                    dependent-hashmap = unmarkBroken (dontCheck (mkCabal2nix {
-                      name = "dependent-hashmap";
-                      source = inputs.alga;
-                    }));
+                    dependent-hashmap = unmarkBroken (dontCheck hp.dependent-hashmap);
 
                     diagnose =
                       hf.callCabal2nixWithOptions "diagnose" (inputs.diagnose)


### PR DESCRIPTION
fix #54 , #14 
Also use `nixfmt` to format `flake.nix` file