### PR TITLE
Improve wasm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,10 @@ cabal.project.local*
 *.ll
 *.bc
 *.o
+/*.wasm
 *.s
 /*.dl
 /*.eclair
+/*.js
 
 result

--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,7 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/luc-tielen/llvm-codegen.git
-    tag: 0021bbaee7b5706567c74fa6c4b20017da617cf0
+    tag: 46500cef30e2522bc0be11ea7adf7b3a0cf4b278
 
 source-repository-package
     type: git

--- a/flake.lock
+++ b/flake.lock
@@ -414,11 +414,11 @@
     "llvm-cg": {
       "flake": false,
       "locked": {
-        "lastModified": 1665998476,
-        "narHash": "sha256-2UQIT3CNqN4Q2YQi8bZzhAKMR+PlGVujNsCyz2PxQI0=",
+        "lastModified": 1666953086,
+        "narHash": "sha256-M4SW/6FpaV+5esHAbijfrR7EvYg6wXmuCG1Mev92NfA=",
         "owner": "luc-tielen",
         "repo": "llvm-codegen",
-        "rev": "0021bbaee7b5706567c74fa6c4b20017da617cf0",
+        "rev": "46500cef30e2522bc0be11ea7adf7b3a0cf4b278",
         "type": "github"
       },
       "original": {

--- a/lib/Eclair/ArgParser.hs
+++ b/lib/Eclair/ArgParser.hs
@@ -4,6 +4,7 @@ module Eclair.ArgParser
   , Config(..)
   , CompileConfig(..)
   , EmitKind(..)
+  , Target(..)
   ) where
 
 import Options.Applicative
@@ -23,7 +24,12 @@ data CompileConfig
   = CompileConfig
   { mainFile :: FilePath
   , emitKind :: EmitKind
+  , cpuTarget :: Maybe Target  -- Nothing = compile to host architecture
   } deriving (Eq, Show)
+
+data Target
+  = Wasm32
+  deriving (Eq, Show)
 
 newtype Config
   = Compile CompileConfig
@@ -52,6 +58,16 @@ compileParser = Compile <$> compileParser'
     compileParser' =
       CompileConfig <$> argument str (metavar "FILE" <> help "The main Datalog file to compile.")
                     <*> emitKindParser
+                    <*> optional targetParser
+
+targetParser :: Parser Target
+targetParser =
+  option (maybeReader parseTarget) $ metavar "TARGET" <> long "target" <> short 't' <> help desc
+  where
+    desc = "Select the target CPU architecture. Default is to use the host architecture. Supported options: 'wasm32'."
+    parseTarget = \case
+      "wasm32" -> Just Wasm32
+      _ -> Nothing
 
 emitKindParser :: Parser EmitKind
 emitKindParser =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -20,4 +20,4 @@ main = do
             EmitRA -> emitRA
             EmitEIR -> emitEIR
             EmitLLVM -> emitLLVM
-      fn file `catch` handleErrors
+      fn (cpuTarget cfg) file `catch` handleErrors

--- a/tests/Test/Eclair/ArgParserSpec.hs
+++ b/tests/Test/Eclair/ArgParserSpec.hs
@@ -27,11 +27,11 @@ spec = describe "argument parsing" $ do
   describe "compile mode" $ parallel $ do
     it "supports 'compile' as the command" $ do
       cfg <- parseArgs' "compile test.dl"
-      cfg `shouldBe` Compile (CompileConfig "test.dl" EmitLLVM)
+      cfg `shouldBe` Compile (CompileConfig "test.dl" EmitLLVM Nothing)
 
     it "supports 'c' as the command" $ do
       cfg <- parseArgs' "c test.dl"
-      cfg `shouldBe` Compile (CompileConfig "test.dl" EmitLLVM)
+      cfg `shouldBe` Compile (CompileConfig "test.dl" EmitLLVM Nothing)
 
     it "supports no other commands" $ do
       shouldFail $ parseArgs' "unknown"
@@ -43,21 +43,28 @@ spec = describe "argument parsing" $ do
     it "supports emitting RA" $ do
       for_ ["ra", "RA"] $ \ra -> do
         cfg <- parseArgs' $ "c test.dl --emit " <> ra
-        cfg `shouldBe` Compile (CompileConfig "test.dl" EmitRA)
+        cfg `shouldBe` Compile (CompileConfig "test.dl" EmitRA Nothing)
 
     it "supports emitting EIR" $ do
       for_ ["eir", "EIR"] $ \eir -> do
         cfg <- parseArgs' $ "c test.dl --emit " <> eir
-        cfg `shouldBe` Compile (CompileConfig "test.dl" EmitEIR)
+        cfg `shouldBe` Compile (CompileConfig "test.dl" EmitEIR Nothing)
 
     it "supports emitting LLVM IR" $ do
       for_ ["llvm", "LLVM"] $ \llvm -> do
         cfg <- parseArgs' $ "c test.dl --emit " <> llvm
-        cfg `shouldBe` Compile (CompileConfig "test.dl" EmitLLVM)
+        cfg `shouldBe` Compile (CompileConfig "test.dl" EmitLLVM Nothing)
 
     it "does not support emitting anything else" $ do
       shouldFail $ parseArgs' "c test.dl --emit unknown-ir"
 
     it "defaults to emitting LLVM IR" $ do
       cfg <- parseArgs' "c test.dl"
-      cfg `shouldBe` Compile (CompileConfig "test.dl" EmitLLVM)
+      cfg `shouldBe` Compile (CompileConfig "test.dl" EmitLLVM Nothing)
+
+    it "parses wasm32 as target architecture" $ do
+      cfg <- parseArgs' "c test.dl -t wasm32"
+      cfg `shouldBe` Compile (CompileConfig "test.dl" EmitLLVM (Just Wasm32))
+
+      cfg2 <- parseArgs' "c test.dl --target wasm32"
+      cfg2 `shouldBe` Compile (CompileConfig "test.dl" EmitLLVM (Just Wasm32))

--- a/tests/lowering/different_types.eclair
+++ b/tests/lowering/different_types.eclair
@@ -13,7 +13,7 @@
 @def a(u32).
 @def b(u32, u32, u32).
 //--- expected_eclair_add_facts_llvm.out
-define external ccc void @eclair_add_facts(%program* %eclair_program_0, i16 %fact_type_0, i32* %memory_0, i32 %fact_count_0) {
+define external ccc void @eclair_add_facts(%program* %eclair_program_0, i16 %fact_type_0, i32* %memory_0, i32 %fact_count_0) "wasm-export-name"="eclair_add_facts" {
 start:
   switch i16 %fact_type_0, label %switch.default_0 [i16 0, label %a_0 i16 1, label %b_0]
 a_0:
@@ -50,7 +50,7 @@ switch.default_0:
   ret void
 }
 //--- expected_eclair_get_facts_llvm.out
-define external ccc i32* @eclair_get_facts(%program* %eclair_program_0, i16 %fact_type_0) {
+define external ccc i32* @eclair_get_facts(%program* %eclair_program_0, i16 %fact_type_0) "wasm-export-name"="eclair_get_facts" {
 start:
   switch i16 %fact_type_0, label %switch.default_0 [i16 0, label %a_0 i16 1, label %b_0]
 a_0:

--- a/tests/lowering/no_top_level_facts.eclair
+++ b/tests/lowering/no_top_level_facts.eclair
@@ -374,7 +374,7 @@ loop.end:
   ret void
 }
 //--- expected_eclair_add_facts_llvm.out
-define external ccc void @eclair_add_facts(%program* %eclair_program_0, i16 %fact_type_0, i32* %memory_0, i32 %fact_count_0) {
+define external ccc void @eclair_add_facts(%program* %eclair_program_0, i16 %fact_type_0, i32* %memory_0, i32 %fact_count_0) "wasm-export-name"="eclair_add_facts" {
 start:
   switch i16 %fact_type_0, label %switch.default_0 [i16 0, label %edge_0 i16 1, label %path_0]
 edge_0:
@@ -411,7 +411,7 @@ switch.default_0:
   ret void
 }
 //--- expected_eclair_get_facts_llvm.out
-define external ccc i32* @eclair_get_facts(%program* %eclair_program_0, i16 %fact_type_0) {
+define external ccc i32* @eclair_get_facts(%program* %eclair_program_0, i16 %fact_type_0) "wasm-export-name"="eclair_get_facts" {
 start:
   switch i16 %fact_type_0, label %switch.default_0 [i16 0, label %edge_0 i16 1, label %path_0]
 edge_0:

--- a/tests/lowering/wasm_codegen.eclair
+++ b/tests/lowering/wasm_codegen.eclair
@@ -1,0 +1,61 @@
+// RUN: split-file %s %t
+
+// RUN: %eclair compile --target wasm32 --emit llvm %t/program.eclair > %t/actual_llvm.out
+// RUN: %extract_snippet %t/actual_llvm.out "@memcmp_wasm32" > %t/actual_wasm_memcmp.out
+// RUN: diff %t/expected_wasm_memcmp.out %t/actual_wasm_memcmp.out
+
+//--- program.eclair
+@def edge(u32, u32).
+@def another(u32, u32, u32).
+
+edge(1, 2).
+
+another(1,2,3).
+
+//--- expected_wasm_memcmp.out
+define external ccc i32 @memcmp_wasm32(i8* %array1_0, i8* %array2_0, i64 %byte_count_0) {
+start:
+  %0 = udiv i64 %byte_count_0, 8
+  %1 = and i64 %byte_count_0, 7
+  %2 = bitcast i8* %array1_0 to i64*
+  %3 = bitcast i8* %array2_0 to i64*
+  br label %for_begin_0
+for_begin_0:
+  %4 = phi i64 [0, %start], [%11, %end_if_0]
+  %5 = icmp ult i64 %4, %0
+  br i1 %5, label %for_body_0, label %for_end_0
+for_body_0:
+  %6 = getelementptr i64, i64* %2, i64 %4
+  %7 = getelementptr i64, i64* %3, i64 %4
+  %8 = load i64, i64* %6
+  %9 = load i64, i64* %7
+  %10 = icmp ne i64 %8, %9
+  br i1 %10, label %if_0, label %end_if_0
+if_0:
+  ret i32 1
+end_if_0:
+  %11 = add i64 1, %4
+  br label %for_begin_0
+for_end_0:
+  %12 = mul i64 %0, 8
+  br label %for_begin_1
+for_begin_1:
+  %13 = phi i64 [0, %for_end_0], [%21, %end_if_1]
+  %14 = icmp ult i64 %13, %1
+  br i1 %14, label %for_body_1, label %for_end_1
+for_body_1:
+  %15 = add i64 %13, %12
+  %16 = getelementptr i8, i8* %array1_0, i64 %15
+  %17 = getelementptr i8, i8* %array2_0, i64 %15
+  %18 = load i8, i8* %16
+  %19 = load i8, i8* %17
+  %20 = icmp ne i8 %18, %19
+  br i1 %20, label %if_1, label %end_if_1
+if_1:
+  ret i32 1
+end_if_1:
+  %21 = add i64 1, %13
+  br label %for_begin_1
+for_end_1:
+  ret i32 0
+}


### PR DESCRIPTION
With this PR we will no longer need an intermediary "C driver file". We can now directly compile Eclair and call it from JS.

Also fixes an issue with `memcmp` not being available for WASM.