### PR TITLE
Fix GHC 9.2.4 compilation warnings

### DIFF
--- a/eclair-lang.cabal
+++ b/eclair-lang.cabal
@@ -92,7 +92,7 @@ library
       FlexibleInstances
       ScopedTypeVariables
       PatternSynonyms
-  ghc-options: -Wall -Wincomplete-patterns -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits
+  ghc-options: -Wall -Wincomplete-patterns -Wno-incomplete-uni-patterns -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits
   cxx-options: -std=c++20 -D__EMBEDDED_SOUFFLE__ -Wall
   build-depends:
       algebraic-graphs ==0.*
@@ -162,7 +162,7 @@ executable eclair
       FlexibleInstances
       ScopedTypeVariables
       PatternSynonyms
-  ghc-options: -Wall -Wincomplete-patterns -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wincomplete-patterns -Wno-incomplete-uni-patterns -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits -threaded -rtsopts -with-rtsopts=-N
   cxx-options: -std=c++20 -D__EMBEDDED_SOUFFLE__
   build-depends:
       algebraic-graphs ==0.*
@@ -235,7 +235,7 @@ test-suite eclair-test
       FlexibleInstances
       ScopedTypeVariables
       PatternSynonyms
-  ghc-options: -Wall -Wincomplete-patterns -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits
+  ghc-options: -Wall -Wincomplete-patterns -Wno-incomplete-uni-patterns -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits
   cxx-options: -std=c++20 -D__EMBEDDED_SOUFFLE__
   build-depends:
       algebraic-graphs ==0.*

--- a/lib/Eclair/Error.hs
+++ b/lib/Eclair/Error.hs
@@ -34,20 +34,20 @@ handleErrors = \case
       FileNotFound {} ->
         hPutStrLn stderr $ "File not found: " <> file'
       ParsingError parseError -> do
-        content <- readFile file'
+        content <- decodeUtf8 <$> readFileBS file'
         let diagnostic = errorDiagnosticFromBundle Nothing "Failed to parse file" Nothing parseError
             diagnostic' = addFile diagnostic file' content
          in renderError diagnostic'
 
   TypeErr file' spanMap errs -> do
-    content <- readFileText file'
+    content <- decodeUtf8 <$> readFileBS file'
     let reports = map (typeErrorToReport file' content spanMap) errs
         diagnostic = foldl' addReport def reports
         diagnostic' = addFile diagnostic file' (toString content)
      in renderError diagnostic'
 
   SemanticErr file' spanMap semanticErr -> do
-    content <- readFileText file'
+    content <- decodeUtf8 <$> readFileBS file'
     let reports = semanticErrorsToReports file' content spanMap semanticErr
         diagnostic = foldl' addReport def reports
         diagnostic' = addFile diagnostic file' (toString content)

--- a/lib/Eclair/Parser.hs
+++ b/lib/Eclair/Parser.hs
@@ -64,7 +64,7 @@ parseFile path = do
   fileExists <- doesFileExist path
   if fileExists
   then do
-    contents <- readFileText path
+    contents <- decodeUtf8 <$> readFileBS path
     pure $ parseText path contents
   else
     pure $ Left $ FileNotFound path

--- a/package.yaml
+++ b/package.yaml
@@ -74,6 +74,7 @@ default-extensions:
 ghc-options:
   - -Wall
   - -Wincomplete-patterns
+  - -Wno-incomplete-uni-patterns
   - -fhide-source-paths
   - -fno-show-valid-hole-fits
   - -fno-sort-valid-hole-fits


### PR DESCRIPTION
+ Added `-Wno-incomplete-uni-patterns` to suppress spurious warnings in various LLVM modules
+ Fixed deprecation warnings about reading file contents in locale dependent manner by changing `readFileText` to `readFileBS`