### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,11 @@ SHELL [ "/bin/bash", "-c" ]
 
 # install packages
 RUN echo 'tzdata tzdata/Areas select Europe' | debconf-set-selections \
-    && echo 'tzdata tzdata/Zones/Europe select Paris' | debconf-set-selections
-RUN apt-get update \
-    && apt-get autoremove -y \
+    && echo 'tzdata tzdata/Zones/Europe select Paris' | debconf-set-selections \
+    && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
        wget software-properties-common gnupg curl libffi-dev make \
        python3 python3-pip libgmp-dev \
-    && rm -rf /var/lib/apt/lists/* \
     && curl -o - https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash \
     && source /root/.nvm/nvm.sh \
     && nvm install 18.1.0 \
@@ -32,13 +30,16 @@ RUN apt-get update \
     && cd - \
     && pip install lit==14.0.6 \
     # install ghcup
-    && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-
-# install and set ghc
-RUN source /root/.ghcup/env \
+    && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh \
+    # install and set ghc
+    && source /root/.ghcup/env \
     && ghcup install ghc --force 9.2.4 && ghcup set ghc 9.2.4 \
     && ghcup install cabal --force 3.6.2.0 && ghcup set cabal 3.6.2.0 \
-    && cabal install hspec-discover
+    && cabal install hspec-discover \
+    && rm -rf /root/.ghcup/ghc/9.2.5 \
+    && apt-get autoremove -y \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 
 VOLUME /code
 WORKDIR /app/build
@@ -52,8 +53,8 @@ ENTRYPOINT [ "/app/build/entrypoint.sh" ]
 
 COPY . .
 
-RUN source /root/.ghcup/env && make build
-RUN echo -e '#!/bin/bash\nsource /root/.ghcup/env\n' > /usr/bin/eclair \
+RUN source /root/.ghcup/env && make build \
+    && echo -e '#!/bin/bash\nsource /root/.ghcup/env\n' > /usr/bin/eclair \
     && source /root/.ghcup/env \
     && echo -e "`cabal list-bin eclair` \"\$@\"" >> /usr/bin/eclair \
     && chmod u+x /usr/bin/eclair


### PR DESCRIPTION
+ `ghcup` was installing `9.2.5` (default latest) in addition to `9.2.4` (the requested version). Removing the unused version trimmed the image size by `2.7 GB`
+  Combined consequent `RUN` commands into a single `RUN` command to reduce layers