### PR TITLE
Rewrite semantic analysis in Eclair itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 .direnv/
 .devcontainer/
 cabal.project.local*
+cbits/*.dl
 
 *.ll
 *.bc

--- a/cbits/semantic_analysis.eclair
+++ b/cbits/semantic_analysis.eclair
@@ -1,99 +1,63 @@
 // Input facts
-.decl lit_number(node_id: unsigned, value: unsigned)
-.decl lit_string(node_id: unsigned, value: symbol)
-.decl variable(node_id: unsigned, var_name: symbol)
-.decl constraint(node_id: unsigned, op: symbol, lhs_node_id: unsigned, rhs_node_id: unsigned)
-.decl binop(node_id: unsigned, op: symbol, lhs_node_id: unsigned, rhs_node_id: unsigned)
-.decl atom(node_id: unsigned, name: symbol)
-.decl atom_arg(atom_id: unsigned, atom_arg_pos: unsigned, atom_arg_id: unsigned)
-.decl rule(rule_id: unsigned, name: symbol)
-.decl rule_arg(rule_id: unsigned, rule_arg_pos: unsigned, rule_arg_id: unsigned)
-.decl rule_clause(rule_id: unsigned, rule_clause_pos: unsigned, rule_clause_id: unsigned)
-.decl negation(negation_node_id: unsigned, inner_node_id: unsigned)
-.decl input_relation(relation_name: symbol)
-.decl output_relation(relation_name: symbol)
-.decl internal_relation(relation_name: symbol)
-.decl extern_definition(node_id: unsigned, extern_name: symbol)
-.decl declare_type(node_id: unsigned, name: symbol)
-.decl module(node_id: unsigned)
-.decl module_declaration(module_id: unsigned, declaration_id: unsigned)
-.decl scoped_value(scope_id: unsigned, value_id: unsigned)
+@def lit_number(u32, u32) input.
+@def lit_string(u32, string) input.
+@def variable(u32, string) input.
+@def constraint(u32, string, u32, u32) input.
+@def binop(u32, string, u32, u32) input.
+@def atom(u32, string) input.
+@def atom_arg(u32, u32, u32) input.
+@def rule(u32, string) input.
+@def rule_arg(u32, u32, u32) input.
+@def rule_clause(u32, u32, u32) input.
+@def negation(u32, u32) input.
+@def input_relation(string) input.
+@def output_relation(string) input.
+@def internal_relation(string) input.
+@def extern_definition(u32, string) input.
+@def declare_type(u32, string) input.
+@def module(u32) input.
+@def module_declaration(u32, u32) input.
+@def scoped_value(u32, u32) input.
 
 // Internal rules
-.decl relation_atom(node_id: unsigned, name: symbol)
-.decl extern_atom(node_id: unsigned, name: symbol)
-.decl grounded_node(rule_node_id: unsigned, node_id: unsigned)
-.decl assign(node_id: unsigned, lhs_node_id: unsigned, rhs_node_id: unsigned) inline
-.decl inequality_op(op: symbol)
-.decl has_output_relation(node_id: unsigned)
-.decl literal_contradiction(lit_id1: unsigned, lit_id2: unsigned)
-.decl wildcard(node_id: unsigned) inline
-.decl rule_head_var(rule_id: unsigned, var_id: unsigned, var_name: symbol)
-.decl alias(rule_id: unsigned, id1: unsigned, id2: unsigned)
-.decl points_to(rule_id: unsigned, id1: unsigned, id2: unsigned)
-.decl depends_on(r1: symbol, r2: symbol)
-.decl transitive_depends_on(r1: symbol, r2: symbol)
-.decl source(r: symbol)
-.decl has_definitions(relation: symbol)
-.decl live_rule(relation: symbol)
-.decl dependency_cycle(relation: symbol)
-.decl rule_scope(rule_id: unsigned, scope_id: unsigned)
-.decl constrained_rule_var(rule_node_id: unsigned, var_node_id: unsigned, var_name: symbol)
+@def relation_atom(u32, string).
+@def extern_atom(u32, string).
+@def grounded_node(u32, u32).
+@def assign(u32, u32, u32). // TODO inline
+@def inequality_op(string).
+@def has_output_relation(u32).
+@def literal_contradiction(u32, u32).
+@def wildcard(u32).  // TODO inline
+@def rule_head_var(u32, u32, string).
+@def alias(u32, u32, u32).
+@def points_to(u32, u32, u32).
+@def depends_on(string, string).
+@def transitive_depends_on(string, string).
+@def source(string).
+@def has_definitions(string).
+@def live_rule(string).
+@def dependency_cycle(string).
+@def rule_scope(u32, u32).
+@def constrained_rule_var(u32, u32, string).
 
 // Output facts / rules
-.decl grounded_variable(rule_id: unsigned, var_name: symbol)
-.decl ungrounded_variable(rule_id: unsigned, var_id: unsigned, var_name: symbol)
-.decl ungrounded_external_atom(rule_id: unsigned, atom_id: unsigned, atom_name: symbol)
-.decl wildcard_in_fact(fact_node_id: unsigned, fact_arg_id: unsigned, pos: unsigned)
-.decl wildcard_in_extern(atom_node_id: unsigned, atom_arg_id: unsigned, pos: unsigned)
-.decl wildcard_in_rule_head(rule_node_id: unsigned, rule_arg_id: unsigned, pos: unsigned)
-.decl wildcard_in_constraint(constraint_node_id: unsigned, wildcard_node_id: unsigned)
-.decl wildcard_in_binop(binop_node_id: unsigned, wildcard_node_id: unsigned)
-.decl unconstrained_rule_var(rule_node_id: unsigned, var_node_id: unsigned, var_name: symbol)
-.decl rule_with_contradiction(rule_id: unsigned)
-.decl dead_code(node_id: unsigned)
-.decl no_output_relation(node_id: unsigned)
-.decl dead_internal_relation(node_id: unsigned, relation_name: symbol)
-.decl conflicting_definitions(node_id1: unsigned, node_id2: unsigned, name: symbol)
-.decl extern_used_as_fact(node_id: unsigned, extern_node_id: unsigned, name: symbol)
-.decl extern_used_as_rule(node_id: unsigned, extern_node_id: unsigned, name: symbol)
-.decl cyclic_negation(negation_id: unsigned)
-
-.input lit_number
-.input lit_string
-.input variable
-.input constraint
-.input binop
-.input atom
-.input atom_arg
-.input rule
-.input rule_arg
-.input rule_clause
-.input negation
-.input input_relation
-.input output_relation
-.input internal_relation
-.input extern_definition
-.input declare_type
-.input module
-.input module_declaration
-.input scoped_value
-
-.output wildcard_in_fact
-.output wildcard_in_extern
-.output ungrounded_variable
-.output ungrounded_external_atom
-.output wildcard_in_rule_head
-.output wildcard_in_constraint
-.output wildcard_in_binop
-.output unconstrained_rule_var
-.output dead_code
-.output no_output_relation
-.output dead_internal_relation
-.output conflicting_definitions
-.output extern_used_as_fact
-.output extern_used_as_rule
-.output cyclic_negation
+@def grounded_variable(u32, string) output.
+@def ungrounded_variable(u32, u32, string) output.
+@def ungrounded_external_atom(u32, u32, string) output.
+@def wildcard_in_fact(u32, u32, u32) output.
+@def wildcard_in_extern(u32, u32, u32) output.
+@def wildcard_in_rule_head(u32, u32, u32) output.
+@def wildcard_in_constraint(u32, u32) output.
+@def wildcard_in_binop(u32, u32) output.
+@def unconstrained_rule_var(u32, u32, string) output.
+@def rule_with_contradiction(u32) output.
+@def dead_code(u32) output.
+@def no_output_relation(u32) output.
+@def dead_internal_relation(u32, string) output.
+@def conflicting_definitions(u32, u32, string) output.
+@def extern_used_as_fact(u32, u32, string) output.
+@def extern_used_as_rule(u32, u32, string) output.
+@def cyclic_negation(u32) output.
 
 // An atom that is not defined externally. This is an important distinction
 // since external atoms cannot ground variables!
@@ -194,12 +158,14 @@ dead_code(rule_id) :-
   rule_clause(rule_id, _, rule_clause_id),
   dead_code(rule_clause_id).
 
+// TODO use inline disjunction for next 2 rules
 has_definitions(r) :-
   module_declaration(_, node_id),
-  (
-    atom(node_id, r);
-    rule(node_id, r)
-  ).
+  atom(node_id, r).
+
+has_definitions(r) :-
+  module_declaration(_, node_id),
+  rule(node_id, r).
 
 // We consider an internal relation to be dead if there are no top level atoms or rules.
 dead_internal_relation(decl_id, r) :-
@@ -391,9 +357,12 @@ alias(rule_id, var_id1, var_id2) :-
   var_id1 != var_id2,
   variable(var_id2, var_name).
 
+// TODO merge these 2 rules again once eclair has support for it
 // Two values are aliases if they are used inside an equality.
 // NOTE: Datalog supports both x = 123 and 123 = x.
-alias(rule_id, id1, id2),
+alias(rule_id, id1, id2) :-
+  rule_clause(rule_id, _, rule_clause_id),
+  assign(rule_clause_id, id1, id2).
 alias(rule_id, id2, id1) :-
   rule_clause(rule_id, _, rule_clause_id),
   assign(rule_clause_id, id1, id2).


### PR DESCRIPTION
This is an important step towards bootstrapping! We can now generate Souffle code from Eclair, and create a "stage0" compiler that way. Then, we can use the stage0 compiler to compile the Eclair code directly (resulting in "stage1", or the final compiler). The stage1 compiler does not depend on Souffle!

Some constructs were rewritten in an equivalent form for now (because Eclair doesn't support some syntactic sugar yet), but they can be reintroduced later. It shouldn't be any difference to the compiler though, because the desugared form is what Souffle compiles it to anyway.