### PR TITLE
Support for GHC-9.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,12 @@ RUN echo 'tzdata tzdata/Areas select Europe' | debconf-set-selections \
     && ln -s wasm-ld-14 wasm-ld \
     && cd - \
     && pip install lit==14.0.6 \
-    # install ghcup
-    && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh \
-    # install and set ghc
+    # install ghcup, ghc-9.4.4 and cabal-3.8.1.0
+    && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | \
+    BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=9.4.4 BOOTSTRAP_HASKELL_CABAL_VERSION=3.8.1.0 \
+    BOOTSTRAP_HASKELL_INSTALL_STACK=1 BOOTSTRAP_HASKELL_INSTALL_HLS=1 BOOTSTRAP_HASKELL_ADJUST_BASHRC=P sh \
     && source /root/.ghcup/env \
-    && ghcup install ghc --force 9.2.7 && ghcup set ghc 9.2.7 \
-    && rm -rf /root/.ghcup/ghc/9.2.5 \
-    && ghcup install cabal --force 3.6.2.0 && ghcup set cabal 3.6.2.0 \
+    && cabal install hpack \
     && cabal install hspec-discover \
     && apt-get autoremove -y \
     && apt-get purge -y --auto-remove \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 _An experimental and minimal Datalog implementation that compiles down to LLVM._
 
+[![Build](https://github.com/luc-tielen/eclair-lang/actions/workflows/build.yml/badge.svg)](https://github.com/luc-tielen/eclair-lang/actions/workflows/build.yml)
+
 ## Features
 
 Eclair is a minimal Datalog (for now). It supports the following features:

--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/luc-tielen/souffle-haskell.git
-    tag: ed29c8dbae4dce85bf66d858944991393fd34645
+    tag: 51786c809e6b5db9d0da80b9821ed87654f620c7
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -3,14 +3,14 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/luc-tielen/llvm-codegen.git
-    tag: 4290b121d2442e5a53ddf6d97da10810d5c94c15
+    tag: 79a839af7c15d6fcd49d575edcef65936b933d94
 
 source-repository-package
     type: git
     location: https://github.com/luc-tielen/souffle-haskell.git
-    tag: a4fa1158ec5fdd0c900ab979e26c90633707fe1e
+    tag: ed29c8dbae4dce85bf66d858944991393fd34645
 
 source-repository-package
     type: git
     location: https://github.com/luc-tielen/diagnose.git
-    tag: 98653e2537445b5fb9d4aeb5477d9bf630d5bebd
+    tag: 24a1d7a2b716d74c1fe44d47941a76c9f5a90c23

--- a/eclair-lang.cabal
+++ b/eclair-lang.cabal
@@ -132,7 +132,7 @@ library
     , prettyprinter ==1.7.*
     , prettyprinter-ansi-terminal ==1.*
     , recursion-schemes ==5.*
-    , relude ==1.1.*
+    , relude ==1.2.*
     , rock ==0.3.*
     , souffle-haskell ==4.0.0
     , text ==2.*
@@ -206,7 +206,7 @@ executable eclair
     , prettyprinter-ansi-terminal ==1.*
     , process ==1.6.*
     , recursion-schemes ==5.*
-    , relude ==1.1.*
+    , relude ==1.2.*
     , rock ==0.3.*
     , souffle-haskell ==4.0.0
     , text ==2.*
@@ -287,7 +287,7 @@ executable eclair-lsp-server
     , prettyprinter ==1.7.*
     , prettyprinter-ansi-terminal ==1.*
     , recursion-schemes ==5.*
-    , relude ==1.1.*
+    , relude ==1.2.*
     , rock ==0.3.*
     , rope-utf16-splay ==0.4.*
     , souffle-haskell ==4.0.0
@@ -364,7 +364,7 @@ test-suite eclair-lsp-test
     , prettyprinter ==1.7.*
     , prettyprinter-ansi-terminal ==1.*
     , recursion-schemes ==5.*
-    , relude ==1.1.*
+    , relude ==1.2.*
     , rock ==0.3.*
     , rope-utf16-splay ==0.4.*
     , souffle-haskell ==4.0.0
@@ -443,7 +443,7 @@ test-suite eclair-test
     , prettyprinter ==1.7.*
     , prettyprinter-ansi-terminal ==1.*
     , recursion-schemes ==5.*
-    , relude ==1.1.*
+    , relude ==1.2.*
     , rock ==0.3.*
     , silently ==1.2.*
     , souffle-haskell ==4.0.0

--- a/package.yaml
+++ b/package.yaml
@@ -25,7 +25,7 @@ dependencies:
     version: ">= 4.7 && < 5"
     mixin:
       - hiding (Prelude)
-  - relude == 1.1.*
+  - relude == 1.2.*
   - extra == 1.*
   - text == 2.*
   - bytestring == 0.11.*
@@ -115,7 +115,7 @@ executables:
         version: ">= 4.7 && < 5"
         mixin:
           - hiding (Prelude)
-      - relude == 1.1.*
+      - relude == 1.2.*
       - directory == 1.*
       - process == 1.6.*
     ghc-options:
@@ -134,7 +134,7 @@ executables:
         version: ">= 4.7 && < 5"
         mixin:
           - hiding (Prelude)
-      - relude == 1.1.*
+      - relude == 1.2.*
       - lsp == 1.4.*
       - lsp-types == 1.4.*
       - lens == 5.2.*


### PR DESCRIPTION
+ Upgraded `relude`, `llvm-codegen`, `souffle-haskell`, `diagnose`
+ Added CI status badge
+ Updated `Dockerfile` for `ghc-9.4.4` and `cabal-3.8.1.0`