### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,18 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - "releases/*"
 jobs:
   hlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: "Set up HLint"
         uses: rwe/actions-hlint-setup@v1
         with:
-          version: "3.1.6"
+          version: "3.6.1"
 
       - name: "Run HLint"
         uses: rwe/actions-hlint-run@v2

--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,7 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/luc-tielen/llvm-codegen.git
-    tag: c97de620ed147388cb6213864d33c63d199561e1
+    tag: 7848818b805d078b1ede82b8b90771d130d45c38
 
 source-repository-package
     type: git


### PR DESCRIPTION
- Upgrade `hlint` version in CI
- Bump up pinned `llvm-codegen` dependency